### PR TITLE
[Brand-569] Update the connect link

### DIFF
--- a/src/components/TopBarNavigation/TopBarNavigation.tsx
+++ b/src/components/TopBarNavigation/TopBarNavigation.tsx
@@ -67,8 +67,8 @@ const TopBarNavigation: FC<Props> = ({ className }) => {
             </SelectContainer>
           </LeftSection>
           <CenterLinks>
-            {Object.values(getMenusAvailable).map((link, index) => (
-              <LinkNavBar href={link.link} label={link.title} selected={activeItem} key={index} />
+            {Object.values(getMenusAvailable).map((link) => (
+              <LinkNavBar href={link.link} label={link.title} selected={activeItem} key={link.title} />
             ))}
           </CenterLinks>
           <RightSection>

--- a/src/core/utils/const.ts
+++ b/src/core/utils/const.ts
@@ -6,4 +6,4 @@ export const MAKER_BURN_LINK = 'https://makerburn.com/#/expenses/core-units';
 export const LOCAL_STORAGE_AUTH_KEY = 'auth';
 export const DELEGATE_PAGE = 'https://vote.makerdao.com/delegates';
 export const UMBRAL_CHART_WATERFALL = 1;
-export const CONNECT = process.env.NEXT_PUBLIC_CONNECT ?? '';
+export const CONNECT = 'https://connect.sky.money/ ';


### PR DESCRIPTION
## Ticket
https://trello.com/c/RVOLfy0j/569-brand-update-for-fusion-launch

## What solved

- [X] Top nav bar the linking to connect: update to https://connect.sky.money/ (currently is https://apps.powerhouse.io/alpha/makerdao/connect/d/MyLocalDrive)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
