### PR TITLE
[Home-537] Fix the height of the line chart in up 1280 size

### DIFF
--- a/src/views/Home/components/FinancesLineChart/FinancesLineChart.tsx
+++ b/src/views/Home/components/FinancesLineChart/FinancesLineChart.tsx
@@ -363,7 +363,7 @@ const Wrapper = styled('div')(({ theme }) => ({
 
   [theme.breakpoints.up('desktop_1280')]: {
     flexDirection: 'column',
-    gap: 32,
+    gap: 14,
   },
 }));
 

--- a/src/views/Home/components/FinancesLineChartCard/FinancesLineChartCard.tsx
+++ b/src/views/Home/components/FinancesLineChartCard/FinancesLineChartCard.tsx
@@ -283,7 +283,7 @@ const InternalButtonContainer = styled('div')(({ theme }) => ({
     marginTop: 16,
   },
   [theme.breakpoints.up('desktop_1280')]: {
-    marginTop: 24,
+    marginTop: 22,
   },
 }));
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/hvGVEox5/537-hom-12-finances-homepage-section

## What solved

- [X]  Should fix issues from QC. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
