### PR TITLE
fix: HeaderCard arrow color in Mobile

### DIFF
--- a/src/views/Home/components/HeaderCard/HeaderCard.tsx
+++ b/src/views/Home/components/HeaderCard/HeaderCard.tsx
@@ -223,11 +223,15 @@ const MobileMenu = styled('div', {
   boxShadow: headerCardData.buttonShadows[0],
 }));
 
-const MobileHeaderButtonContainer = styled('div')(() => ({
+const MobileHeaderButtonContainer = styled('div')(({ theme }) => ({
   width: '100%',
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
+
+  '& svg path': {
+    fill: theme.palette.colors.gray[900],
+  },
 }));
 
 const MobileHeaderButton = styled(Button)(({ theme }) => ({


### PR DESCRIPTION
## Description
fix: HeaderCard arrow color in Mobile

## What solved

- [X] fix: HeaderCard arrow color in Mobile

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook