### PR TITLE
[Reskin-486] Add the dark mode for title component

### DIFF
--- a/src/views/Finances/components/FinancesTitle/FinancesTitle.tsx
+++ b/src/views/Finances/components/FinancesTitle/FinancesTitle.tsx
@@ -126,6 +126,11 @@ const IconWrapper = styled('div')(({ theme }) => ({
   [lightTheme.breakpoints.up('tablet_768')]: {
     alignItems: 'center',
   },
+  ':hover': {
+    '& path': {
+      fill: theme.palette.isLight ? theme.palette.colors.slate[200] : theme.palette.colors.slate[100],
+    },
+  },
 }));
 
 const CopyWrapper = styled(Link)(({ theme }) => ({
@@ -135,13 +140,14 @@ const CopyWrapper = styled(Link)(({ theme }) => ({
   width: 24,
   height: 24,
   color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.slate[200],
-
   '& svg': {
     width: 20,
     height: 20,
   },
-
   cursor: 'pointer',
+  ':hover': {
+    color: theme.palette.isLight ? theme.palette.colors.slate[200] : theme.palette.colors.slate[100],
+  },
 }));
 
 const Date = styled('div')(({ theme }) => ({


### PR DESCRIPTION


## Ticket
https://trello.com/c/6H8x1mXD/486-reskin-finances-breakdown-chart

## What solved
- [X] Should update the title with an info icon and open icon (status: default, hover) for light/dark mode. Desktop/Small resolutions.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
