### PR TITLE
[Reskin-485] Fix nav box sizing

### DIFF
--- a/src/views/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
+++ b/src/views/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
@@ -189,4 +189,5 @@ const CardWrapper = styled('div')({
   display: 'flex',
   flex: '1',
   height: '100%',
+  boxSizing: 'border-box',
 });


### PR DESCRIPTION
## Ticket
https://trello.com/c/lHsgd1Nv/485-reskin-finances-main-section

## Description
The cards with long titles were taking more space than expected

## What solved

- [X] Should display the cards with hidden descriptions in the same size. (e.g., /finances/scopes/PRO?year=2024) 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook