### PR TITLE
[Reskin-486] Add the correct padding in 1280 breakpoint

### DIFF
--- a/src/views/Home/components/FinancesBarChartCard/FinancesBarChartCard.tsx
+++ b/src/views/Home/components/FinancesBarChartCard/FinancesBarChartCard.tsx
@@ -343,7 +343,7 @@ const LegendButton = styled(Button, {
     height: 24,
     fontSize: 16,
     lineHeight: '24px',
-
+    width: 'max-content',
     '& .MuiButton-startIcon': {
       transform: 'scale(1.5)',
     },


### PR DESCRIPTION
## Ticket
https://trello.com/c/6H8x1mXD/486-reskin-finances-breakdown-chart


## What solved

- [X] Add the text in the finances section in home page

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
