### PR TITLE
feat: improve pie chart loading and minor UI details

### DIFF
--- a/src/views/Finances/FinancesView.tsx
+++ b/src/views/Finances/FinancesView.tsx
@@ -101,7 +101,6 @@ const FinancesView: React.FC<Props> = ({ budgets, allBudgets, yearsRange, initia
               seriesData={cardOverViewSectionData.doughnutSeriesData}
               handleMetricChange={cardOverViewSectionData.handleSelectedMetric}
               // legend
-              isCoreThirdLevel={levelNumber >= 3}
               changeAlignment={cardOverViewSectionData.changeAlignment}
               showSwiper={cardOverViewSectionData.showSwiper}
               numberSliderPerLevel={cardOverViewSectionData.numberSliderPerLevel}

--- a/src/views/Finances/components/CardNavigationFinance/CardNavigationFinance.tsx
+++ b/src/views/Finances/components/CardNavigationFinance/CardNavigationFinance.tsx
@@ -129,6 +129,9 @@ const Code = styled('div')(({ theme }) => ({
   fontWeight: 600,
   lineHeight: '24px',
   color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.gray[600],
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
 
   [theme.breakpoints.up('tablet_768')]: {
     alignSelf: 'center',

--- a/src/views/Finances/components/SectionPages/CardChartOverview/OverviewCardKeyDetailsBudget/DoughnutChartFinances/CardLegend.tsx
+++ b/src/views/Finances/components/SectionPages/CardChartOverview/OverviewCardKeyDetailsBudget/DoughnutChartFinances/CardLegend.tsx
@@ -52,6 +52,8 @@ const ContainerLegend = styled('div')<{ isCoreThirdLevel: boolean; changeAlignme
 
     [theme.breakpoints.up('desktop_1280')]: {
       columnGap: 24,
+      rowGap: isCoreThirdLevel ? 10 : 8,
+      marginTop: isCoreThirdLevel ? 6 : 0,
     },
   })
 );

--- a/src/views/Finances/components/SectionPages/CardChartOverview/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinancesSkeleton.tsx
+++ b/src/views/Finances/components/SectionPages/CardChartOverview/OverviewCardKeyDetailsBudget/DoughnutChartFinances/DoughnutChartFinancesSkeleton.tsx
@@ -41,21 +41,21 @@ const DoughnutChartFinancesSkeleton: React.FC = () => (
           <Skeleton variant="circular" width={8} height={8} />
           <Skeleton variant="rounded" width={135} height={12} />
         </ChartLegendLabel>
-        <Skeleton variant="rounded" width={106} height={7} style={{ marginLeft: 12 }} />
+        <Skeleton variant="rounded" width={106} height={12} style={{ marginLeft: 12 }} />
       </ChartLegendItem>
       <ChartLegendItem>
         <ChartLegendLabel>
           <Skeleton variant="circular" width={8} height={8} />
           <Skeleton variant="rounded" width={143} height={12} />
         </ChartLegendLabel>
-        <Skeleton variant="rounded" width={115} height={7} style={{ marginLeft: 12 }} />
+        <Skeleton variant="rounded" width={115} height={12} style={{ marginLeft: 12 }} />
       </ChartLegendItem>
       <ChartLegendItem>
         <ChartLegendLabel>
           <Skeleton variant="circular" width={8} height={8} />
           <Skeleton variant="rounded" width={156} height={12} />
         </ChartLegendLabel>
-        <Skeleton variant="rounded" width={104} height={7} style={{ marginLeft: 12 }} />
+        <Skeleton variant="rounded" width={104} height={12} style={{ marginLeft: 12 }} />
       </ChartLegendItem>
     </ChartLegendContainer>
   </ChartContainer>
@@ -99,22 +99,41 @@ const SVG = styled('svg')(({ theme }) => ({
     width: 148,
     height: 148,
   },
+
+  '& path': {
+    '&:nth-of-type(1)': {
+      fill: theme.palette.isLight ? '#ECF1F3' : '#373E4D',
+      stroke: theme.palette.isLight ? '#ECF1F3' : '#373E4D',
+    },
+    '&:nth-of-type(2)': {
+      fill: theme.palette.isLight ? '#CED3DC' : '#485265B2',
+      stroke: theme.palette.isLight ? '#CED3DC' : '#485265B2',
+    },
+    '&:nth-of-type(3)': {
+      fill: theme.palette.isLight ? '#E6E9ED' : '#48526566',
+      stroke: theme.palette.isLight ? '#E6E9ED' : '#48526566',
+    },
+  },
 }));
 
 const ChartLegendContainer = styled('div')(() => ({
   display: 'flex',
   flexDirection: 'column',
-  gap: 24,
+  gap: 16,
 }));
 
 const ChartLegendItem = styled('div')(() => ({
   display: 'flex',
   flexDirection: 'column',
-  gap: 6.5,
+  gap: 4,
+
+  '& .MuiSkeleton-rounded': {
+    borderRadius: '4px!important',
+  },
 }));
 
 const ChartLegendLabel = styled('div')(() => ({
   display: 'flex',
-  alignItems: 'flex-end',
+  alignItems: 'center',
   gap: 4,
 }));

--- a/src/views/Finances/components/SectionPages/CardChartOverview/OverviewCardKeyDetailsBudget/DoughnutChartFinances/ItemLegendDoughnut.tsx
+++ b/src/views/Finances/components/SectionPages/CardChartOverview/OverviewCardKeyDetailsBudget/DoughnutChartFinances/ItemLegendDoughnut.tsx
@@ -108,7 +108,8 @@ const ValueDescription = styled('div')<{ isCoreThirdLevel: boolean }>(({ theme, 
   }),
 
   [theme.breakpoints.up('desktop_1280')]: {
-    fontSize: 14,
+    fontSize: isCoreThirdLevel ? 12 : 14,
+    lineHeight: isCoreThirdLevel ? '15px' : 'normal',
   },
 }));
 
@@ -123,15 +124,15 @@ const NameOrCode = styled('div')<{ isCoreThirdLevel: boolean }>(({ theme, isCore
   color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
   fontSize: 12,
   fontWeight: 600,
-  lineHeight: isCoreThirdLevel ? '15px' : '18px',
+  lineHeight: '15px',
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   width: isCoreThirdLevel ? 'fit-content' : 170,
 
   [theme.breakpoints.up('desktop_1280')]: {
-    fontSize: 14,
-    lineHeight: '24px',
+    fontSize: isCoreThirdLevel ? 12 : 14,
+    lineHeight: isCoreThirdLevel ? '15px' : '24px',
   },
 }));
 

--- a/src/views/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/views/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -256,7 +256,7 @@ export const useCardChartOverview = (
       : 5
     : isDesk1280
     ? numberItems >= 10
-      ? 10
+      ? 12
       : 5
     : 5;
 

--- a/src/views/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
+++ b/src/views/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
@@ -130,7 +130,6 @@ const ContainerCardsNavigation = styled('div')<{ showSwiper: boolean; isCompact:
 
 const SwiperWrapper = styled('div')(({ theme }) => ({
   position: 'relative',
-  marginBottom: 32,
   maxWidth: '100%',
   width: '100%',
 

--- a/src/views/Finances/components/SectionPages/OverviewSection/OverviewSection.tsx
+++ b/src/views/Finances/components/SectionPages/OverviewSection/OverviewSection.tsx
@@ -13,7 +13,6 @@ interface OverviewSectionProps {
   selectedMetric: AnalyticMetric;
   handleMetricChange: (metric: AnalyticMetric) => void;
   // legend
-  isCoreThirdLevel: boolean;
   changeAlignment: boolean;
   showSwiper: boolean;
   numberSliderPerLevel?: number;
@@ -26,7 +25,6 @@ const OverviewSection: React.FC<OverviewSectionProps> = ({
   selectedMetric,
   handleMetricChange,
   changeAlignment,
-  isCoreThirdLevel,
   showSwiper,
   numberSliderPerLevel,
 }) => (
@@ -36,7 +34,6 @@ const OverviewSection: React.FC<OverviewSectionProps> = ({
       seriesData={seriesData}
       selectedMetric={selectedMetric}
       handleMetricChange={handleMetricChange}
-      isCoreThirdLevel={isCoreThirdLevel}
       changeAlignment={changeAlignment}
       showSwiper={showSwiper}
       numberSliderPerLevel={numberSliderPerLevel}

--- a/src/views/Finances/components/SectionPages/OverviewSection/UtilizationChart/DesktopChart/DesktopChart.tsx
+++ b/src/views/Finances/components/SectionPages/OverviewSection/UtilizationChart/DesktopChart/DesktopChart.tsx
@@ -24,7 +24,6 @@ import 'swiper/css';
 interface DesktopChartProps {
   seriesData: DoughnutSeries[];
   selectedMetric: AnalyticMetric;
-  isCoreThirdLevel?: boolean;
   changeAlignment: boolean;
   showSwiper: boolean;
   numberSliderPerLevel?: number;
@@ -33,7 +32,6 @@ interface DesktopChartProps {
 const DesktopChart: React.FC<DesktopChartProps> = ({
   seriesData,
   selectedMetric,
-  isCoreThirdLevel = true,
   changeAlignment,
   showSwiper,
   numberSliderPerLevel = 6,
@@ -43,6 +41,7 @@ const DesktopChart: React.FC<DesktopChartProps> = ({
   const theme = useTheme();
   const [visibleSeries, setVisibleSeries] = useState<DoughnutSeries[]>(seriesData);
   const [legends, setLegends] = useState<DoughnutSeries[]>(seriesData);
+  const isDeepLevel = seriesData.length > 6;
 
   useEffect(() => {
     setVisibleSeries(seriesData);
@@ -289,7 +288,7 @@ const DesktopChart: React.FC<DesktopChartProps> = ({
   }
 
   return (
-    <Container isCoreThirdLevel={isCoreThirdLevel}>
+    <Container isCoreThirdLevel={isDeepLevel}>
       <ContainerChart>
         <ReactECharts
           ref={chartRef}
@@ -306,7 +305,7 @@ const DesktopChart: React.FC<DesktopChartProps> = ({
         </ContainerDaiIcon>
       </ContainerChart>
       {showSwiper ? (
-        <SwiperWrapper isCoreThirdLevel={isCoreThirdLevel} numberSliderPerLevel={numberSliderPerLevel}>
+        <SwiperWrapper isCoreThirdLevel={isDeepLevel} numberSliderPerLevel={numberSliderPerLevel}>
           <Swiper
             direction="horizontal"
             ref={ref}
@@ -316,7 +315,7 @@ const DesktopChart: React.FC<DesktopChartProps> = ({
             {...swiperOptions}
           >
             <ContainerLegend
-              isCoreThirdLevel={isCoreThirdLevel}
+              isCoreThirdLevel={isDeepLevel}
               changeAlignment={changeAlignment}
               numberSlider={numberSlider}
             >
@@ -329,7 +328,7 @@ const DesktopChart: React.FC<DesktopChartProps> = ({
                     toggleSeriesVisibility={toggleSeriesVisibility}
                     onLegendItemHover={onLegendItemHover}
                     onLegendItemLeave={onLegendItemLeave}
-                    isCoreThirdLevel={isCoreThirdLevel}
+                    isCoreThirdLevel={isDeepLevel}
                   />
                 </SwiperSlide>
               ))}
@@ -344,7 +343,7 @@ const DesktopChart: React.FC<DesktopChartProps> = ({
             toggleSeriesVisibility={toggleSeriesVisibility}
             onLegendItemHover={onLegendItemHover}
             onLegendItemLeave={onLegendItemLeave}
-            isCoreThirdLevel={isCoreThirdLevel}
+            isCoreThirdLevel={isDeepLevel}
           />
         </ContainerLegendNotSwiper>
       )}
@@ -437,7 +436,7 @@ const SwiperWrapper = styled('div')<{ isCoreThirdLevel: boolean; numberSliderPer
     [theme.breakpoints.up('desktop_1280')]: {
       display: 'flex',
       position: 'relative',
-      ...(numberSliderPerLevel === 10 && {
+      ...(numberSliderPerLevel === 12 && {
         minWidth: 365,
       }),
     },
@@ -445,7 +444,7 @@ const SwiperWrapper = styled('div')<{ isCoreThirdLevel: boolean; numberSliderPer
     [theme.breakpoints.up('desktop_1440')]: {
       display: 'flex',
       position: 'relative',
-      ...(numberSliderPerLevel === 10 && {
+      ...(numberSliderPerLevel === 12 && {
         minWidth: 440,
       }),
     },

--- a/src/views/Finances/components/SectionPages/OverviewSection/UtilizationChart/UtilizationChart.tsx
+++ b/src/views/Finances/components/SectionPages/OverviewSection/UtilizationChart/UtilizationChart.tsx
@@ -10,7 +10,6 @@ interface UtilizationChartProps {
   seriesData: DoughnutSeries[];
   selectedMetric: AnalyticMetric;
   handleMetricChange: (metric: AnalyticMetric) => void;
-  isCoreThirdLevel: boolean;
   changeAlignment: boolean;
   showSwiper: boolean;
   numberSliderPerLevel?: number;
@@ -20,7 +19,6 @@ const UtilizationChart: React.FC<UtilizationChartProps> = ({
   seriesData,
   selectedMetric,
   handleMetricChange,
-  isCoreThirdLevel,
   changeAlignment,
   showSwiper,
   numberSliderPerLevel,
@@ -32,7 +30,6 @@ const UtilizationChart: React.FC<UtilizationChartProps> = ({
       <DesktopChart
         seriesData={seriesData}
         selectedMetric={selectedMetric}
-        isCoreThirdLevel={isCoreThirdLevel}
         changeAlignment={changeAlignment}
         showSwiper={showSwiper}
         numberSliderPerLevel={numberSliderPerLevel}


### PR DESCRIPTION
## Ticket
https://trello.com/c/lHsgd1Nv/485-reskin-finances-main-section

## Description
Improve skeleton loading state in the pie chart of the budget utilization section. Also improves some UI details around the budget utilization section

## What solved

- [X] Should update the loading state for the pie chart section for light/dark mode. Desktop resolutions.
- [X] Should update the loading state for the pie chart section for light/dark mode. Small resolutions.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook
