### PR TITLE
[Reskin-486] Allow to reset the filters

### DIFF
--- a/src/views/Finances/components/BreakdownChartSection/useBreakdownChart.ts
+++ b/src/views/Finances/components/BreakdownChartSection/useBreakdownChart.ts
@@ -189,9 +189,10 @@ const useBreakdownChart = (budgets: Budget[], year: string, codePath: string, al
     },
   ];
   //
-  const canReset = false;
+  const canReset = selectedGranularity !== 'monthly' || selectedMetric !== 'Budget';
   const onReset = () => {
-    console.log('delete');
+    setSelectedMetric('Budget');
+    setSelectedGranularity('monthly');
   };
   // Show the toggle and scroll in the legend of the chart
   const showScrollAndToggle = series.length > 8;


### PR DESCRIPTION
## Ticket
https://trello.com/c/6H8x1mXD/486-reskin-finances-breakdown-chart


## What solved

- [X] Allow the filter to reset the filters
- [X] Should add the icon filter with all the statuses for light/dark mode. Small resolutions. 


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
