### PR TITLE
[Reskin-486]   Should update the tooltip for light/dark mode. 

### DIFF
--- a/src/views/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/views/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -115,6 +115,7 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
           if (yPos + tooltipHeight + MORE_WITH > window.innerHeight) {
             yPos -= tooltipHeight;
           }
+          return [xPos, yPos];
         },
 
         formatter: function (params: BarChartSeries[]) {


### PR DESCRIPTION
## Ticket
https://trello.com/c/6H8x1mXD/486-reskin-finances-breakdown-chart


## What solved

- [X] Should update the tooltip for light/dark mode. Small resolutions. **PR**https://github.com/powerhouse-inc/fusion/pull/50 **Added: ** The tooltip on the left side of the screen partially extends beyond the boundaries of the website.

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have performed a self-review of my chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
