### PR TITLE
[Reskin-491] Breakdown table header

### DIFF
--- a/src/views/Finances/components/BreakdownTableFinances/BreakdownTableFinances.tsx
+++ b/src/views/Finances/components/BreakdownTableFinances/BreakdownTableFinances.tsx
@@ -19,7 +19,7 @@ const BreakdownTableFinances = ({ year, filters, resetFilters }: Props) => (
     />
 
     <FilterContainer>
-      <FiltersBundle filters={filters} resetFilters={resetFilters} asPopover={[]} />
+      <FiltersBundle filters={filters} resetFilters={resetFilters} asPopover={[]} snapPoints={[450, 250, 0]} />
     </FilterContainer>
   </Container>
 );

--- a/src/views/Finances/components/HeaderTable/HeaderAnnually/CellAnnually.tsx
+++ b/src/views/Finances/components/HeaderTable/HeaderAnnually/CellAnnually.tsx
@@ -1,44 +1,34 @@
-import styled from '@emotion/styled';
-import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { styled } from '@mui/material';
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
-import lightTheme from '@ses/styles/theme/themes';
-import React from 'react';
 import type { MetricValues } from '@/views/Finances/utils/types';
 import { getKeyMetric, getShortNameForMetric } from '@/views/Finances/utils/utils';
-
-import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
   metrics: Partial<MetricValues>;
   activeMetrics: string[];
 }
 
-export const CellAnnually: React.FC<Props> = ({ metrics, activeMetrics }) => {
-  const { isLight } = useThemeContext();
-  return (
-    <ContainerCell isLight={isLight} activeMetrics={activeMetrics.length}>
-      {activeMetrics?.map((metric, index) => (
-        <Metrics isLight={isLight} key={index}>
-          <Name isLight={isLight}>{getShortNameForMetric(metric)}</Name>
-          <Amount isLight={isLight}>
-            {usLocalizedNumber(metrics[getKeyMetric(metric) as keyof MetricValues] ?? 0)}
-          </Amount>
-        </Metrics>
-      ))}
-    </ContainerCell>
-  );
-};
+export const CellAnnually: React.FC<Props> = ({ metrics, activeMetrics }) => (
+  <ContainerCell activeMetrics={activeMetrics.length}>
+    {activeMetrics?.map((metric, index) => (
+      <Metrics key={index}>
+        <Name>{getShortNameForMetric(metric)}</Name>
+        <Amount>{usLocalizedNumber(metrics[getKeyMetric(metric) as keyof MetricValues] ?? 0)}</Amount>
+      </Metrics>
+    ))}
+  </ContainerCell>
+);
 
 export default CellAnnually;
 
-const ContainerCell = styled.div<WithIsLight & { activeMetrics: number }>(({ isLight, activeMetrics }) => ({
+const ContainerCell = styled('div')<{ activeMetrics: number }>(({ theme, activeMetrics }) => ({
   fontFamily: 'Inter, sans-serif',
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'center',
-  color: isLight ? '#231536' : '#D2D4EF',
   width: '100%',
   fontWeight: 500,
+
   ...(activeMetrics === 3 && {
     '& > div:nth-of-type(3)': {
       ':after': {
@@ -46,6 +36,7 @@ const ContainerCell = styled.div<WithIsLight & { activeMetrics: number }>(({ isL
       },
     },
   }),
+
   ...(activeMetrics === 2 && {
     '& > div:nth-of-type(2)': {
       ':after': {
@@ -55,59 +46,68 @@ const ContainerCell = styled.div<WithIsLight & { activeMetrics: number }>(({ isL
       },
     },
   }),
-  [lightTheme.breakpoints.up('desktop_1440')]: {
+
+  [theme.breakpoints.up('desktop_1440')]: {
     gap: 60,
     paddingLeft: 20,
   },
 }));
 
-const Metrics = styled.div<WithIsLight>(({ isLight }) => ({
+const Metrics = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   width: 80,
   flex: 1,
   position: 'relative',
+  padding: 0,
+
   ':after': {
     content: '""',
     position: 'absolute',
     height: 48,
-    bottom: 4,
-    borderRight: `1px solid ${isLight ? '#D1DEE6' : '#546978'}`,
+    bottom: 10,
+    borderRight: `1px solid ${
+      theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.charcoal[800]
+    }`,
   },
-  padding: 0,
-  [lightTheme.breakpoints.up('tablet_768')]: {
+
+  [theme.breakpoints.up('tablet_768')]: {
     ':after': {
       display: 'none',
     },
   },
-  [lightTheme.breakpoints.up('desktop_1280')]: {
+
+  [theme.breakpoints.up('desktop_1280')]: {
     width: 192,
   },
-  [lightTheme.breakpoints.up('desktop_1440')]: {
+
+  [theme.breakpoints.up('desktop_1440')]: {
     width: 78,
   },
 }));
-const Name = styled.div<WithIsLight>({
-  marginBottom: 4,
-  fontSize: 11,
-  fontWeight: 500,
+
+const Name = styled('div')(({ theme }) => ({
+  fontSize: 12,
+  fontWeight: 400,
   textAlign: 'center',
   fontStyle: 'normal',
   lineHeight: 'normal',
-  color: '#708390',
-  [lightTheme.breakpoints.up('desktop_1024')]: {
+  marginBottom: 4,
+  color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.gray[700],
+
+  [theme.breakpoints.up('desktop_1024')]: {
     textAlign: 'center',
   },
-  [lightTheme.breakpoints.up('desktop_1920')]: {
+
+  [theme.breakpoints.up('desktop_1920')]: {
     marginBottom: 2,
   },
-});
-const Amount = styled.div<WithIsLight>(({ isLight }) => ({
-  color: isLight ? '#231536' : '#D2D4EF',
-  fontSize: 11,
+}));
+
+const Amount = styled('div')(({ theme }) => ({
+  fontSize: 12,
   fontWeight: 600,
+  lineHeight: '18px',
   textAlign: 'center',
-  [lightTheme.breakpoints.up('tablet_768')]: {
-    fontSize: 12,
-  },
+  color: theme.palette.isLight ? theme.palette.colors.slate[900] : theme.palette.colors.gray[200],
 }));

--- a/src/views/Finances/components/HeaderTable/HeaderAnnually/HeaderAnnually.tsx
+++ b/src/views/Finances/components/HeaderTable/HeaderAnnually/HeaderAnnually.tsx
@@ -1,12 +1,8 @@
-import styled from '@emotion/styled';
-import { useThemeContext } from '@ses/core/context/ThemeContext';
-import lightTheme from '@ses/styles/theme/themes';
-import React from 'react';
+import { styled } from '@mui/material';
 import type { MetricValues } from '@/views/Finances/utils/types';
 import { filterActiveMetrics } from '@/views/Finances/utils/utils';
 import { orderMetrics } from '../utils';
 import CellAnnually from './CellAnnually';
-import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
   year: string;
@@ -16,18 +12,16 @@ interface Props {
 }
 
 export const HeaderAnnually: React.FC<Props> = ({ year, title, activeMetrics, headerTable }) => {
-  const { isLight } = useThemeContext();
-
   const metricsActive = filterActiveMetrics(activeMetrics, headerTable);
 
   return (
-    <Container isLight={isLight}>
+    <Container>
       <ContainerAnnually>
-        <ContainerTitle isLight={isLight}>
-          <Title isLight={isLight}>{title}</Title>
+        <ContainerTitle>
+          <Title>{title}</Title>
         </ContainerTitle>
         <ContainerYear>
-          <Year isLight={isLight}>{year}</Year>
+          <Year>{year}</Year>
           <ContainerAnnuallyCell>
             <CellAnnually metrics={metricsActive[0]} activeMetrics={orderMetrics(undefined, activeMetrics)} />
           </ContainerAnnuallyCell>
@@ -39,58 +33,49 @@ export const HeaderAnnually: React.FC<Props> = ({ year, title, activeMetrics, he
 
 export default HeaderAnnually;
 
-const ContainerAnnually = styled.div({
+const Container = styled('div')(({ theme }) => ({
+  fontFamily: 'Inter, sans-serif',
   display: 'flex',
-  flexDirection: 'row',
-  alignItems: 'center',
-  padding: '16px 8px',
   flex: 1,
-  whiteSpace: 'break-spaces',
-  [lightTheme.breakpoints.up('tablet_768')]: {
-    padding: '16px 8px',
-  },
-  [lightTheme.breakpoints.up('desktop_1280')]: {
-    padding: '16px 32px',
-  },
-  [lightTheme.breakpoints.up('desktop_1440')]: {
-    maxWidth: 1312,
-  },
-});
+  justifyContent: 'flex-start',
+  borderRadius: 12,
+  backgroundColor: theme.palette.isLight ? theme.palette.colors.slate[50] : '#212630',
+  boxShadow: theme.palette.isLight ? theme.fusionShadows.chartsShadows : '1px 4px 15.3px 0px #141921',
+  alignItems: 'center',
+  whiteSpace: 'pre',
+  overflow: 'hidden',
+  minHeight: 83,
 
-const Year = styled.div<WithIsLight>(({ isLight }) => ({
-  textAlign: 'center',
-  fontSize: 14,
-  fontWeight: 500,
-  fontStyle: 'normal',
-  lineHeight: 'normal',
-  marginBottom: 8,
-  color: isLight ? '#231536' : '#D2D4EF',
-  [lightTheme.breakpoints.up('tablet_768')]: {
-    marginBottom: 24,
-    fontSize: 18,
+  '&::-webkit-scrollbar': {
+    width: 0,
+    height: 0,
   },
 }));
 
-const ContainerAnnuallyCell = styled.div({
+const ContainerAnnually = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
-  justifyContent: 'space-between',
   alignItems: 'center',
-  width: '100%',
-  [lightTheme.breakpoints.up('tablet_768')]: {
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    width: '100%',
-  },
-});
+  padding: 8,
+  flex: 1,
+  whiteSpace: 'break-spaces',
 
-const Title = styled.div<WithIsLight>(({ isLight }) => ({
-  color: isLight ? '#231536' : '#D2D4EF',
-  fontFamily: 'Inter, sans-serif',
-  fontSize: 11,
-  fontStyle: 'normal',
+  [theme.breakpoints.up('tablet_768')]: {
+    padding: '16px 8px',
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
+    padding: '16px 32px',
+  },
+
+  [theme.breakpoints.up('desktop_1440')]: {
+    maxWidth: 1312,
+  },
+}));
+
+const Title = styled('div')(({ theme }) => ({
+  color: theme.palette.isLight ? theme.palette.colors.slate[900] : theme.palette.colors.gray[200],
+  fontSize: 12,
   fontWeight: 700,
   lineHeight: 'normal',
   whiteSpace: 'break-spaces',
@@ -98,61 +83,74 @@ const Title = styled.div<WithIsLight>(({ isLight }) => ({
   wordWrap: 'break-word',
   paddingRight: 8,
 
-  [lightTheme.breakpoints.up('tablet_768')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     fontSize: 16,
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
+    whiteSpace: 'revert',
   },
 }));
 
-const ContainerTitle = styled.div<WithIsLight>({
+const ContainerTitle = styled('div')(({ theme }) => ({
   width: 78,
   minWidth: 78,
   display: 'flex',
   alignItems: 'center',
   whiteSpace: 'break-spaces',
-  [lightTheme.breakpoints.up('tablet_768')]: {
+
+  [theme.breakpoints.up('tablet_768')]: {
     width: 140,
     height: 48,
   },
-  [lightTheme.breakpoints.up('desktop_1024')]: {
-    width: 140,
-  },
-  [lightTheme.breakpoints.up('desktop_1024')]: {
-    width: 140,
-  },
-  [lightTheme.breakpoints.up('desktop_1280')]: {
+
+  [theme.breakpoints.up('desktop_1280')]: {
     width: 190,
   },
-  [lightTheme.breakpoints.up('desktop_1440')]: {
+
+  [theme.breakpoints.up('desktop_1440')]: {
     width: 170,
   },
-  [lightTheme.breakpoints.up('desktop_1920')]: {
+
+  [theme.breakpoints.up('desktop_1920')]: {
     width: 195,
   },
-});
+}));
 
-const ContainerYear = styled.div({
+const Year = styled('div')(({ theme }) => ({
+  fontSize: 14,
+  fontWeight: 600,
+  lineHeight: '22px',
+  marginBottom: 8,
+  textAlign: 'center',
+  color: theme.palette.isLight ? theme.palette.colors.slate[900] : theme.palette.colors.gray[200],
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    fontSize: 20,
+    lineHeight: 'normal',
+    letterSpacing: '0.4px',
+  },
+}));
+
+const ContainerAnnuallyCell = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  width: '100%',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: '100%',
+  },
+}));
+
+const ContainerYear = styled('div')({
   display: 'flex',
   flex: 1,
   flexDirection: 'column',
   alignItems: 'center',
 });
-
-const Container = styled.div<WithIsLight>(({ isLight }) => ({
-  fontFamily: 'Inter, sans-serif',
-  display: 'flex',
-  flex: 1,
-  justifyContent: 'flex-start',
-  borderRadius: 6,
-  backgroundColor: isLight ? '#E5E9EC' : '#405361',
-  boxShadow: isLight
-    ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)'
-    : '0px 1px 3px 0px rgba(30, 23, 23, 0.25), 0px 20px 40px -40px rgba(7, 22, 40, 0.40)',
-
-  alignItems: 'center',
-  whiteSpace: 'pre',
-  overflow: 'hidden',
-  '&::-webkit-scrollbar': {
-    width: 0,
-    height: 0,
-  },
-}));

--- a/src/views/Finances/components/HeaderTable/HeaderMonthly/CellMonthly.tsx
+++ b/src/views/Finances/components/HeaderTable/HeaderMonthly/CellMonthly.tsx
@@ -1,11 +1,7 @@
-import styled from '@emotion/styled';
-import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { styled } from '@mui/material';
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
-import lightTheme from '@ses/styles/theme/themes';
-import React from 'react';
 import type { MetricValues } from '@/views/Finances/utils/types';
 import { getKeyMetric, getShortNameForMetric } from '@/views/Finances/utils/utils';
-import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
   title: string;
@@ -15,77 +11,87 @@ interface Props {
   activeMetrics: string[];
 }
 
-export const CellMonthly: React.FC<Props> = ({ metrics, title, isTotal = false, className, activeMetrics }) => {
-  const { isLight } = useThemeContext();
-  return (
-    <ContainerCell isLight={isLight} isTotal={isTotal} className={className}>
-      <Month isLight={isLight}>{title}</Month>
-      {activeMetrics?.map((metric, index) => (
-        <Metrics key={index}>
-          <Name isLight={isLight}>{getShortNameForMetric(metric)}</Name>
-          <Amount isLight={isLight}>
-            {usLocalizedNumber(metrics[getKeyMetric(metric) as keyof MetricValues] ?? 0)}
-          </Amount>
-        </Metrics>
-      ))}
-    </ContainerCell>
-  );
-};
+export const CellMonthly: React.FC<Props> = ({ metrics, title, isTotal = false, className, activeMetrics }) => (
+  <ContainerCell isTotal={isTotal} className={className}>
+    <Month>{title}</Month>
+    {activeMetrics?.map((metric, index) => (
+      <Metrics key={index}>
+        <Name>{getShortNameForMetric(metric)}</Name>
+        <Amount>{usLocalizedNumber(metrics[getKeyMetric(metric) as keyof MetricValues] ?? 0)}</Amount>
+      </Metrics>
+    ))}
+  </ContainerCell>
+);
 
 export default CellMonthly;
 
-const ContainerCell = styled.div<WithIsLight & { isTotal: boolean }>(({ isLight, isTotal }) => ({
+const ContainerCell = styled('div')<{ isTotal: boolean }>(({ theme, isTotal }) => ({
+  position: 'relative',
   fontFamily: 'Inter, sans-serif',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
   justifyContent: 'center',
-  color: isLight ? '#231536' : '#D2D4EF',
   minWidth: 87,
   fontWeight: 500,
-  backgroundColor: isLight ? (isTotal ? 'rgba(209, 222, 230, 0.50)' : 'transparent') : isTotal ? '#374752' : '#405361',
+  backgroundColor: isTotal
+    ? theme.palette.isLight
+      ? theme.palette.colors.gray[200]
+      : theme.palette.colors.charcoal[900]
+    : 'transparent',
+
   ...(isTotal && {
     padding: '16px 0px 16px 0px',
+    marginTop: -16,
+    marginBottom: -16,
   }),
-  [lightTheme.breakpoints.up('desktop_1920')]: {
+
+  ...(!isTotal && {
+    ':after': {
+      content: '""',
+      position: 'absolute',
+      height: 48,
+      left: 0,
+      borderRight: `1px solid ${
+        theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.charcoal[800]
+      }`,
+    },
+  }),
+
+  [theme.breakpoints.up('desktop_1920')]: {
     minWidth: 80,
   },
 }));
 
-const Month = styled.div<WithIsLight>(({ isLight }) => ({
-  color: isLight ? '#231536' : '#D2D4EF',
+const Month = styled('div')(({ theme }) => ({
   textAlign: 'center',
-  fontFamily: 'Inter, sans-serif',
-  fontSize: 18,
+  fontSize: 20,
   fontStyle: 'normal',
-  fontWeight: 500,
+  fontWeight: 600,
   lineHeight: 'normal',
+  color: theme.palette.isLight ? theme.palette.colors.slate[900] : theme.palette.colors.gray[200],
   marginBottom: 8,
 }));
 
-const Metrics = styled.div({
+const Metrics = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   width: 70.5,
 });
-const Name = styled.div<WithIsLight>({
+
+const Name = styled('div')(({ theme }) => ({
   marginBottom: 4,
-  fontSize: 11,
-  fontWeight: 500,
+  fontSize: 12,
+  fontWeight: 400,
   textAlign: 'center',
   fontStyle: 'normal',
   lineHeight: 'normal',
-  color: '#708390',
-  [lightTheme.breakpoints.up('desktop_1024')]: {
-    textAlign: 'center',
-  },
-  [lightTheme.breakpoints.up('desktop_1920')]: {
-    marginBottom: 2,
-  },
-});
-const Amount = styled.div<WithIsLight>(({ isLight }) => ({
-  color: isLight ? '#231536' : '#D2D4EF',
+  color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.gray[700],
+}));
+
+const Amount = styled('div')(({ theme }) => ({
   fontSize: 12,
   fontWeight: 600,
   textAlign: 'center',
+  color: theme.palette.isLight ? theme.palette.colors.slate[900] : theme.palette.colors.gray[200],
 }));

--- a/src/views/Finances/components/HeaderTable/HeaderMonthly/HeaderMonthly.tsx
+++ b/src/views/Finances/components/HeaderTable/HeaderMonthly/HeaderMonthly.tsx
@@ -1,12 +1,8 @@
-import styled from '@emotion/styled';
-import { useThemeContext } from '@ses/core/context/ThemeContext';
-import lightTheme from '@ses/styles/theme/themes';
-import React from 'react';
+import { styled } from '@mui/material';
 import type { MetricValues } from '@/views/Finances/utils/types';
 import { filterActiveMetrics } from '@/views/Finances/utils/utils';
 import { orderMetrics } from '../utils';
 import CellMonthly from './CellMonthly';
-import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
   title: string;
@@ -18,12 +14,11 @@ export const HeaderMonthly: React.FC<Props> = ({ title, activeMetrics, headerTab
   const keysMetrics = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec', 'Total'];
   const metricsActive = filterActiveMetrics(activeMetrics, headerTable);
 
-  const { isLight } = useThemeContext();
   return (
-    <Container isLight={isLight}>
+    <Container>
       <ContainerAnnually>
         <ContainerTitle>
-          <Title isLight={isLight}>{title}</Title>
+          <Title>{title}</Title>
         </ContainerTitle>
         <ContainerYear>
           <ContainerAnnuallyCell>
@@ -33,6 +28,7 @@ export const HeaderMonthly: React.FC<Props> = ({ title, activeMetrics, headerTab
                 title={month}
                 key={month}
                 activeMetrics={orderMetrics(undefined, activeMetrics)}
+                isTotal={month === 'Total'}
               />
             ))}
           </ContainerAnnuallyCell>
@@ -44,35 +40,37 @@ export const HeaderMonthly: React.FC<Props> = ({ title, activeMetrics, headerTab
 
 export default HeaderMonthly;
 
-const Container = styled.div<WithIsLight>(({ isLight }) => ({
+const Container = styled('div')(({ theme }) => ({
   fontFamily: 'Inter, sans-serif',
   display: 'flex',
   flex: 1,
   justifyContent: 'flex-start',
-  borderRadius: 6,
-  backgroundColor: isLight ? '#E5E9EC' : '#405361',
-  boxShadow: isLight ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)' : 'red',
+  borderRadius: 12,
+  backgroundColor: theme.palette.isLight ? theme.palette.colors.slate[50] : '#212630',
+  boxShadow: theme.palette.isLight ? theme.fusionShadows.chartsShadows : '1px 4px 15.3px 0px #141921',
   alignItems: 'center',
   whiteSpace: 'pre',
   overflow: 'hidden',
-  height: 97,
+  minHeight: 93,
+
   '&::-webkit-scrollbar': {
     width: 0,
     height: 0,
   },
 }));
-const ContainerAnnually = styled.div({
+
+const ContainerAnnually = styled('div')(({ theme }) => ({
   display: 'flex',
   flex: 1,
   flexDirection: 'row',
   alignItems: 'center',
 
-  [lightTheme.breakpoints.up('desktop_1440')]: {
+  [theme.breakpoints.up('desktop_1440')]: {
     maxWidth: 1312,
   },
-});
+}));
 
-const ContainerAnnuallyCell = styled.div({
+const ContainerAnnuallyCell = styled('div')({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'space-between',
@@ -82,8 +80,8 @@ const ContainerAnnuallyCell = styled.div({
   paddingBottom: 10,
 });
 
-const Title = styled.div<WithIsLight>(({ isLight }) => ({
-  color: isLight ? '#231536' : '#D2D4EF',
+const Title = styled('div')(({ theme }) => ({
+  color: theme.palette.isLight ? theme.palette.colors.slate[900] : theme.palette.colors.gray[200],
   fontFamily: 'Inter, sans-serif',
   fontSize: 16,
   fontStyle: 'normal',
@@ -95,7 +93,7 @@ const Title = styled.div<WithIsLight>(({ isLight }) => ({
   paddingRight: 8,
 }));
 
-const ContainerTitle = styled.div({
+const ContainerTitle = styled('div')(({ theme }) => ({
   display: 'flex',
   padding: '16px 0px 16px 32px',
   alignItems: 'center',
@@ -103,12 +101,13 @@ const ContainerTitle = styled.div({
   height: 48,
   paddingTop: 10,
   paddingBottom: 10,
-  [lightTheme.breakpoints.up('desktop_1920')]: {
+
+  [theme.breakpoints.up('desktop_1920')]: {
     minWidth: 230,
   },
-});
+}));
 
-const ContainerYear = styled.div({
+const ContainerYear = styled('div')({
   display: 'flex',
   flex: 1,
   flexDirection: 'column',

--- a/src/views/Finances/components/HeaderTable/HeaderQuarterly/CellQuarterly.tsx
+++ b/src/views/Finances/components/HeaderTable/HeaderQuarterly/CellQuarterly.tsx
@@ -1,11 +1,7 @@
-import styled from '@emotion/styled';
-import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { styled } from '@mui/material';
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
-import lightTheme from '@ses/styles/theme/themes';
-import React from 'react';
 import type { MetricValues } from '@/views/Finances/utils/types';
 import { getKeyMetric, getShortNameForMetric } from '@/views/Finances/utils/utils';
-import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
   quarterly: string;
@@ -15,30 +11,25 @@ interface Props {
   activeMetrics: string[];
 }
 
-export const CellQuarterly: React.FC<Props> = ({ metrics, activeMetrics, quarterly, isTotal = false, className }) => {
-  const { isLight } = useThemeContext();
-  return (
-    <MainContainer isLight={isLight} isTotal={isTotal} className={className}>
-      <ContainerCell>
-        <Quarterly isLight={isLight}>{quarterly}</Quarterly>
-        <ContainerMetricsData>
-          {activeMetrics?.map((metric, index) => (
-            <Metrics key={index}>
-              <Name isLight={isLight}>{getShortNameForMetric(metric)}</Name>
-              <Amount isLight={isLight}>
-                {usLocalizedNumber(metrics?.[getKeyMetric(metric) as keyof MetricValues] ?? 0)}
-              </Amount>
-            </Metrics>
-          ))}
-        </ContainerMetricsData>
-      </ContainerCell>
-    </MainContainer>
-  );
-};
+export const CellQuarterly: React.FC<Props> = ({ metrics, activeMetrics, quarterly, isTotal = false, className }) => (
+  <MainContainer isTotal={isTotal} className={className}>
+    <ContainerCell>
+      <Quarterly>{quarterly}</Quarterly>
+      <ContainerMetricsData>
+        {activeMetrics?.map((metric, index) => (
+          <Metrics key={index}>
+            <Name>{getShortNameForMetric(metric)}</Name>
+            <Amount>{usLocalizedNumber(metrics?.[getKeyMetric(metric) as keyof MetricValues] ?? 0)}</Amount>
+          </Metrics>
+        ))}
+      </ContainerMetricsData>
+    </ContainerCell>
+  </MainContainer>
+);
 
 export default CellQuarterly;
 
-const MainContainer = styled.div<WithIsLight & { isTotal: boolean }>(({ isLight, isTotal }) => ({
+const MainContainer = styled('div')<{ isTotal: boolean }>(({ theme, isTotal }) => ({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'center',
@@ -46,113 +37,131 @@ const MainContainer = styled.div<WithIsLight & { isTotal: boolean }>(({ isLight,
   width: isTotal ? 105 : 96,
   alignItems: 'center',
   padding: isTotal ? '16px 0px 16px 8px' : '16px 4px',
-  backgroundColor: isLight ? (isTotal ? 'rgba(209, 222, 230, 0.50)' : 'transparent') : isTotal ? '#374752' : '#405361)',
+  backgroundColor: isTotal
+    ? theme.palette.isLight
+      ? theme.palette.colors.gray[200]
+      : theme.palette.colors.charcoal[900]
+    : 'transparent',
+
   ...(!isTotal && {
     ':after': {
       content: '""',
       position: 'relative',
       height: 48,
       left: 10,
-      borderRight: `1px solid ${isLight ? '#D1DEE6' : '#546978'}`,
-      [lightTheme.breakpoints.up('tablet_768')]: {
-        left: 6,
+      borderRight: `1px solid ${
+        theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.charcoal[800]
+      }`,
+
+      [theme.breakpoints.up('tablet_768')]: {
+        left: 5,
       },
-      [lightTheme.breakpoints.up('desktop_1024')]: {
+      [theme.breakpoints.up('desktop_1024')]: {
         left: 4,
       },
-      [lightTheme.breakpoints.up('desktop_1280')]: {
+      [theme.breakpoints.up('desktop_1280')]: {
         left: 0,
       },
 
-      [lightTheme.breakpoints.up('desktop_1440')]: {
+      [theme.breakpoints.up('desktop_1440')]: {
         left: 0,
       },
-      [lightTheme.breakpoints.up('desktop_1920')]: {
+      [theme.breakpoints.up('desktop_1920')]: {
         left: 2,
       },
     },
   }),
-  [lightTheme.breakpoints.up('desktop_1024')]: {
-    width: isTotal ? 144 : 100,
 
+  [theme.breakpoints.up('desktop_1024')]: {
+    width: isTotal ? 144 : 100,
     padding: isTotal ? '16px 4px 16px' : '16px 4px',
   },
-  [lightTheme.breakpoints.up('desktop_1280')]: {
+
+  [theme.breakpoints.up('desktop_1280')]: {
     width: isTotal ? 162 : 190,
     padding: isTotal ? '16px 1px' : '16px 0px',
   },
-  [lightTheme.breakpoints.up('desktop_1440')]: {
+
+  [theme.breakpoints.up('desktop_1440')]: {
     minWidth: isTotal ? 197 : 191,
     padding: '16px 0px',
   },
-  [lightTheme.breakpoints.up('desktop_1920')]: {
+
+  [theme.breakpoints.up('desktop_1920')]: {
     minWidth: isTotal ? 285 : 284,
   },
 }));
 
-const ContainerCell = styled.div({
-  [lightTheme.breakpoints.up('tablet_768')]: {
+const ContainerCell = styled('div')(({ theme }) => ({
+  [theme.breakpoints.up('tablet_768')]: {
     display: 'flex',
     flex: 1,
     flexDirection: 'column',
     alignItems: 'center',
   },
-});
-const Quarterly = styled.div<WithIsLight>(({ isLight }) => ({
-  fontFamily: 'Inter, sans-serif',
-  marginBottom: 6,
-  fontWeight: 700,
-  fontSize: 16,
-  color: isLight ? '#231536' : '#D2D4EF',
+}));
 
-  [lightTheme.breakpoints.up('desktop_1280')]: {
+const Quarterly = styled('div')(({ theme }) => ({
+  marginBottom: 8,
+  fontSize: 16,
+  fontWeight: 700,
+  lineHeight: 'normal',
+  color: theme.palette.isLight ? theme.palette.colors.slate[900] : theme.palette.colors.gray[200],
+
+  [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 20,
     fontWeight: 600,
     letterSpacing: '0.4px',
   },
 }));
-const ContainerMetricsData = styled.div({
+
+const ContainerMetricsData = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
 
-  [lightTheme.breakpoints.up('desktop_1024')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     width: '100%',
     flexDirection: 'row',
     justifyContent: 'center',
   },
-});
-const Metrics = styled.div({
+}));
+
+const Metrics = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   minWidth: 77.5,
-  [lightTheme.breakpoints.up('desktop_1280')]: {
+
+  [theme.breakpoints.up('desktop_1280')]: {
     minWidth: 83.5,
   },
-  [lightTheme.breakpoints.up('desktop_1440')]: {
+
+  [theme.breakpoints.up('desktop_1440')]: {
     minWidth: 93.5,
   },
-  [lightTheme.breakpoints.up('desktop_1920')]: {
+
+  [theme.breakpoints.up('desktop_1920')]: {
     minWidth: 80,
   },
-});
-const Name = styled.div<WithIsLight>(({ isLight }) => ({
+}));
+
+const Name = styled('div')(({ theme }) => ({
   marginBottom: 4,
-  fontSize: 11,
+  fontSize: 12,
   fontWeight: 500,
   textAlign: 'center',
   fontStyle: 'normal',
   lineHeight: 'normal',
-  color: isLight ? '#708390' : '#708390',
-  [lightTheme.breakpoints.up('desktop_1024')]: {
-    textAlign: 'center',
-  },
-  [lightTheme.breakpoints.up('desktop_1920')]: {
-    marginBottom: 2,
+  color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.gray[700],
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    fontWeight: 400,
   },
 }));
-const Amount = styled.div<WithIsLight>(({ isLight }) => ({
-  color: isLight ? '#231536' : '#D2D4EF',
+
+const Amount = styled('div')(({ theme }) => ({
   fontSize: 12,
   fontWeight: 600,
+  lineHeight: 'normal',
   textAlign: 'center',
+  color: theme.palette.isLight ? theme.palette.colors.slate[900] : theme.palette.colors.gray[200],
 }));

--- a/src/views/Finances/components/HeaderTable/HeaderQuarterly/HeaderQuarterly.tsx
+++ b/src/views/Finances/components/HeaderTable/HeaderQuarterly/HeaderQuarterly.tsx
@@ -1,12 +1,8 @@
-import styled from '@emotion/styled';
-import { useThemeContext } from '@ses/core/context/ThemeContext';
-import lightTheme from '@ses/styles/theme/themes';
-import React from 'react';
+import { styled } from '@mui/material';
 import type { MetricValues } from '@/views/Finances/utils/types';
 import { filterActiveMetrics } from '@/views/Finances/utils/utils';
 import { orderMetrics } from '../utils';
 import CellQuarterly from './CellQuarterly';
-import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
   title: string;
@@ -17,14 +13,13 @@ interface Props {
 }
 
 const HeaderQuarterly: React.FC<Props> = ({ title, className, headerTable, year, activeMetrics }) => {
-  const { isLight } = useThemeContext();
   const keysMetrics = [...[1, 2, 3, 4].map((quarter) => `Q${quarter} ${year}`), 'Total'];
   const metricsActive = filterActiveMetrics(activeMetrics, headerTable);
 
   return (
-    <Container isLight={isLight} className={className}>
-      <TitleContainer isLight={isLight}>
-        <Title isLight={isLight}>{title}</Title>
+    <Container className={className}>
+      <TitleContainer>
+        <Title>{title}</Title>
       </TitleContainer>
 
       <ContainerCell>
@@ -34,6 +29,7 @@ const HeaderQuarterly: React.FC<Props> = ({ title, className, headerTable, year,
             quarterly={quarterly}
             key={index}
             activeMetrics={orderMetrics(undefined, activeMetrics)}
+            isTotal={quarterly === 'Total'}
           />
         ))}
       </ContainerCell>
@@ -43,28 +39,27 @@ const HeaderQuarterly: React.FC<Props> = ({ title, className, headerTable, year,
 
 export default HeaderQuarterly;
 
-const Container = styled.div<WithIsLight>(({ isLight }) => ({
+const Container = styled('div')(({ theme }) => ({
   fontFamily: 'Inter, sans-serif',
   display: 'flex',
   flex: 1,
   justifyContent: 'flex-start',
-  borderRadius: 6,
-  backgroundColor: isLight ? '#E5E9EC' : '#405361',
-  boxShadow: isLight
-    ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)'
-    : '0px 1px 3px 0px rgba(30, 23, 23, 0.25), 0px 20px 40px -40px rgba(7, 22, 40, 0.40)',
+  borderRadius: 12,
+  backgroundColor: theme.palette.isLight ? theme.palette.colors.slate[50] : '#212630',
+  boxShadow: theme.palette.isLight ? theme.fusionShadows.chartsShadows : '1px 4px 15.3px 0px #141921',
   alignItems: 'center',
   whiteSpace: 'pre',
   overflow: 'hidden',
-  height: 97,
+  minHeight: 83,
+
   '&::-webkit-scrollbar': {
     width: 0,
     height: 0,
   },
 }));
 
-const Title = styled.div<WithIsLight>(({ isLight }) => ({
-  color: isLight ? '#231536' : '#D2D4EF',
+const Title = styled('div')(({ theme }) => ({
+  color: theme.palette.isLight ? theme.palette.colors.slate[900] : theme.palette.colors.gray[200],
   fontFamily: 'Inter, sans-serif',
   fontSize: 16,
   fontStyle: 'normal',
@@ -75,43 +70,50 @@ const Title = styled.div<WithIsLight>(({ isLight }) => ({
   wordWrap: 'break-word',
   paddingRight: 8,
 
-  [lightTheme.breakpoints.up('desktop_1280')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
+    fontWeight: 700,
+  },
+
+  [theme.breakpoints.up('desktop_1280')]: {
     whiteSpace: 'normal',
     wordWrap: 'break-word',
   },
 }));
 
-const TitleContainer = styled.div<WithIsLight>(({ isLight }) => ({
+const TitleContainer = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'flex-start',
   alignItems: 'center',
   minHeight: 48,
-  borderRight: `1px solid ${isLight ? '#D1DEE6' : '#546978'}`,
+  borderRight: `1px solid ${
+    theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.charcoal[800]
+  }`,
   width: 145,
   padding: '16px 8px 16px 8px',
-  [lightTheme.breakpoints.up('desktop_1024')]: {
+
+  [theme.breakpoints.up('desktop_1024')]: {
     width: 148,
     padding: '16px 0px 16px 8px',
   },
-  [lightTheme.breakpoints.up('desktop_1280')]: {
-    width: 220,
 
+  [theme.breakpoints.up('desktop_1280')]: {
+    width: 220,
     padding: '16px 0px 16px 32px',
   },
 
-  [lightTheme.breakpoints.up('desktop_1440')]: {
+  [theme.breakpoints.up('desktop_1440')]: {
     width: 260,
     padding: '16px 8px 16px 32px',
   },
-  [lightTheme.breakpoints.up('desktop_1920')]: {
-    width: 228,
 
+  [theme.breakpoints.up('desktop_1920')]: {
+    width: 228,
     padding: '16px 0px 16px 16px',
   },
 }));
 
-const ContainerCell = styled.div({
+const ContainerCell = styled('div')({
   display: 'flex',
   flexDirection: 'row',
   flex: 1,

--- a/src/views/Finances/components/HeaderTable/HeaderSemiAnnual/CellSemiAnnual.tsx
+++ b/src/views/Finances/components/HeaderTable/HeaderSemiAnnual/CellSemiAnnual.tsx
@@ -1,10 +1,7 @@
-import styled from '@emotion/styled';
-import { useThemeContext } from '@ses/core/context/ThemeContext';
+import { styled } from '@mui/material';
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
-import React from 'react';
 import type { MetricValues } from '@/views/Finances/utils/types';
 import { getKeyMetric, getShortNameForMetric } from '@/views/Finances/utils/utils';
-import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
   semiannual: string;
@@ -14,82 +11,92 @@ interface Props {
   activeMetrics: string[];
 }
 
-export const CellSemiAnnual: React.FC<Props> = ({ metrics, semiannual, isTotal = false, className, activeMetrics }) => {
-  const { isLight } = useThemeContext();
-
-  return (
-    <MainContainer isLight={isLight} isTotal={isTotal} className={className}>
-      <ContainerCell>
-        <Semiannual isLight={isLight}>{semiannual}</Semiannual>
-        <ContainerMetricsData>
-          {activeMetrics?.map((metric, index) => (
-            <Metrics key={index}>
-              <Name isLight={isLight}>{getShortNameForMetric(metric)}</Name>
-              <Amount isLight={isLight}>
-                {usLocalizedNumber(metrics[getKeyMetric(metric) as keyof MetricValues] ?? 0)}
-              </Amount>
-            </Metrics>
-          ))}
-        </ContainerMetricsData>
-      </ContainerCell>
-    </MainContainer>
-  );
-};
+export const CellSemiAnnual: React.FC<Props> = ({ metrics, semiannual, isTotal = false, className, activeMetrics }) => (
+  <MainContainer isTotal={isTotal} className={className}>
+    <ContainerCell>
+      <Semiannual>{semiannual}</Semiannual>
+      <ContainerMetricsData>
+        {activeMetrics?.map((metric, index) => (
+          <Metrics key={index}>
+            <Name>{getShortNameForMetric(metric)}</Name>
+            <Amount>{usLocalizedNumber(metrics[getKeyMetric(metric) as keyof MetricValues] ?? 0)}</Amount>
+          </Metrics>
+        ))}
+      </ContainerMetricsData>
+    </ContainerCell>
+  </MainContainer>
+);
 
 export default CellSemiAnnual;
 
-const MainContainer = styled.div<WithIsLight & { isTotal: boolean }>(({ isLight, isTotal }) => ({
+const MainContainer = styled('div')<{ isTotal: boolean }>(({ theme, isTotal }) => ({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'center',
   flex: 1,
   width: isTotal ? 71 : 78,
   alignItems: 'center',
-  backgroundColor: isLight ? (isTotal ? 'rgba(209, 222, 230, 0.50)' : 'transparent') : isTotal ? '#2D3C48' : '#405361',
-  ...(!isTotal && {
-    ':after': {
-      content: '""',
-      position: 'relative',
-      height: 48,
-      borderLeft: `1px solid ${isLight ? '#D1DEE6' : '#546978'}`,
-    },
+  backgroundColor: isTotal
+    ? theme.palette.isLight
+      ? theme.palette.colors.gray[200]
+      : theme.palette.colors.charcoal[900]
+    : 'transparent',
+
+  ...(isTotal && {
+    marginTop: -8,
+    marginBottom: -8,
   }),
+
+  '&:not(:last-of-type):after': {
+    content: '""',
+    position: 'relative',
+    height: 48,
+    borderLeft: `1px solid ${
+      theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.charcoal[800]
+    }`,
+  },
 }));
 
-const ContainerCell = styled.div({
+const ContainerCell = styled('div')({
   display: 'flex',
   flex: 1,
   flexDirection: 'column',
   alignItems: 'center',
 });
-const Semiannual = styled.div<WithIsLight>(({ isLight }) => ({
-  fontFamily: 'Inter, sans-serif',
-  marginBottom: 6,
-  fontWeight: 500,
+
+const Semiannual = styled('div')(({ theme }) => ({
   fontSize: 14,
-  color: isLight ? '#231536' : '#D2D4EF',
+  fontWeight: 600,
+  lineHeight: '22px',
+  marginBottom: 8,
+  color: theme.palette.isLight ? theme.palette.colors.slate[900] : theme.palette.colors.gray[200],
 }));
-const ContainerMetricsData = styled.div({
+
+const ContainerMetricsData = styled('div')({
   display: 'flex',
   flexDirection: 'column',
 });
-const Metrics = styled.div({
+
+const Metrics = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   minWidth: 70,
 });
-const Name = styled.div<WithIsLight>(({ isLight }) => ({
-  marginBottom: 4,
-  fontSize: 11,
-  fontWeight: 500,
+
+const Name = styled('div')(({ theme }) => ({
+  fontSize: 12,
+  fontWeight: 400,
   textAlign: 'center',
   fontStyle: 'normal',
   lineHeight: 'normal',
-  color: isLight ? '#708390' : '#D2D4EF',
+  marginBottom: 4,
+  color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.gray[700],
 }));
-const Amount = styled.div<WithIsLight>(({ isLight }) => ({
-  color: isLight ? '#231536' : '#D2D4EF',
+
+const Amount = styled('div')(({ theme }) => ({
   fontSize: 12,
   fontWeight: 600,
+  lineHeight: '18px',
   textAlign: 'center',
+  color: theme.palette.isLight ? theme.palette.colors.slate[900] : theme.palette.colors.gray[200],
 }));

--- a/src/views/Finances/components/HeaderTable/HeaderSemiAnnual/HeaderSemiAnnual.tsx
+++ b/src/views/Finances/components/HeaderTable/HeaderSemiAnnual/HeaderSemiAnnual.tsx
@@ -1,12 +1,8 @@
-import styled from '@emotion/styled';
-import { useThemeContext } from '@ses/core/context/ThemeContext';
-import lightTheme from '@ses/styles/theme/themes';
-import React from 'react';
+import { styled } from '@mui/material';
 import type { MetricValues, PeriodicSelectionFilter } from '@/views/Finances/utils/types';
 import { filterActiveMetrics } from '@/views/Finances/utils/utils';
 import { orderMetrics } from '../utils';
 import CellSemiAnnual from './CellSemiAnnual';
-import type { WithIsLight } from '@ses/core/utils/typesHelpers';
 
 interface Props {
   title: string;
@@ -18,14 +14,13 @@ interface Props {
 }
 
 const HeaderSemiAnnual: React.FC<Props> = ({ title, className, activeMetrics, headerTable, year }) => {
-  const { isLight } = useThemeContext();
-  const keysMetrics = [`H${1} ${year}`, `H${2} ${year}`, 'Total'];
+  const keysMetrics = [`H${1}'${year.substring(2, 4)}`, `H${2}'${year.substring(2, 4)}`, 'Total'];
   const metricsActive = filterActiveMetrics(activeMetrics, headerTable);
 
   return (
-    <Container isLight={isLight} className={className}>
-      <TitleContainer isLight={isLight}>
-        <Title isLight={isLight}>{title}</Title>
+    <Container className={className}>
+      <TitleContainer>
+        <Title>{title}</Title>
       </TitleContainer>
 
       <ContainerCell>
@@ -35,6 +30,7 @@ const HeaderSemiAnnual: React.FC<Props> = ({ title, className, activeMetrics, he
             semiannual={period}
             key={index}
             activeMetrics={orderMetrics(undefined, activeMetrics)}
+            isTotal={period === 'Total'}
           />
         ))}
       </ContainerCell>
@@ -44,55 +40,55 @@ const HeaderSemiAnnual: React.FC<Props> = ({ title, className, activeMetrics, he
 
 export default HeaderSemiAnnual;
 
-const Container = styled.div<WithIsLight>(({ isLight }) => ({
+const Container = styled('div')(({ theme }) => ({
   fontFamily: 'Inter, sans-serif',
   display: 'flex',
   flex: 1,
   justifyContent: 'flex-start',
-  borderRadius: 6,
+  borderRadius: 12,
   paddingTop: 8,
   paddingBottom: 8,
-  backgroundColor: isLight ? '#E5E9EC' : '#405361',
-  boxShadow: isLight
-    ? '0px 1px 3px 0px rgba(190, 190, 190, 0.25), 0px 20px 40px 0px rgba(219, 227, 237, 0.40)'
-    : '0px 1px 3px 0px rgba(30, 23, 23, 0.25), 0px 20px 40px -40px rgba(7, 22, 40, 0.40)',
+  backgroundColor: theme.palette.isLight ? theme.palette.colors.slate[50] : '#212630',
+  boxShadow: theme.palette.isLight ? theme.fusionShadows.chartsShadows : '1px 4px 15.3px 0px #141921',
   alignItems: 'center',
   whiteSpace: 'pre',
   overflow: 'hidden',
-  minHeight: 87,
+  minHeight: 83,
+
   '&::-webkit-scrollbar': {
     width: 0,
     height: 0,
   },
 }));
 
-const Title = styled.div<WithIsLight>(({ isLight }) => ({
-  color: isLight ? '#231536' : '#D2D4EF',
-  fontFamily: 'Inter, sans-serif',
-  fontSize: 11,
-  fontStyle: 'normal',
-  fontWeight: 600,
+const Title = styled('div')(({ theme }) => ({
+  color: theme.palette.isLight ? theme.palette.colors.slate[900] : theme.palette.colors.gray[200],
+  fontSize: 12,
+  fontWeight: 700,
   lineHeight: 'normal',
   whiteSpace: 'break-spaces',
   maxWidth: '100%',
   wordWrap: 'break-word',
   paddingRight: 8,
 
-  [lightTheme.breakpoints.up('tablet_768')]: {
+  [theme.breakpoints.up('tablet_768')]: {
     fontSize: 16,
   },
-  [lightTheme.breakpoints.up('desktop_1280')]: {
+
+  [theme.breakpoints.up('desktop_1280')]: {
     whiteSpace: 'revert',
   },
 }));
 
-const TitleContainer = styled.div<WithIsLight>(({ isLight }) => ({
+const TitleContainer = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'flex-start',
   alignItems: 'center',
   height: 48,
-  borderRight: `1px solid ${isLight ? '#D1DEE6' : '#546978'}`,
+  borderRight: `1px solid ${
+    theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.charcoal[800]
+  }`,
   width: 85,
   minWidth: 85,
   padding: '16px 0px 16px 8px',
@@ -101,12 +97,13 @@ const TitleContainer = styled.div<WithIsLight>(({ isLight }) => ({
   wordBreak: 'break-word',
 }));
 
-const ContainerCell = styled.div({
+const ContainerCell = styled('div')({
   display: 'flex',
   flexDirection: 'row',
   flex: 1,
   alignItems: 'center',
+
   '& > div:last-of-type': {
-    minHeight: 87,
+    minHeight: 83,
   },
 });

--- a/src/views/Finances/components/HeaderTable/HeaderTable.tsx
+++ b/src/views/Finances/components/HeaderTable/HeaderTable.tsx
@@ -1,11 +1,10 @@
 import { useMediaQuery } from '@mui/material';
-import lightTheme from '@ses/styles/theme/themes';
-import React from 'react';
 import HeaderAnnually from './HeaderAnnually/HeaderAnnually';
 import HeaderMonthly from './HeaderMonthly/HeaderMonthly';
 import HeaderQuarterly from './HeaderQuarterly/HeaderQuarterly';
 import HeaderSemiAnnual from './HeaderSemiAnnual/HeaderSemiAnnual';
 import type { MetricValues, PeriodicSelectionFilter } from '../../utils/types';
+import type { Theme } from '@mui/material';
 
 interface Props {
   period: PeriodicSelectionFilter;
@@ -16,7 +15,7 @@ interface Props {
 }
 
 const HeaderTable: React.FC<Props> = ({ title, year, period, headerTable, activeMetrics }) => {
-  const isPhone = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
+  const isPhone = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
 
   if (isPhone && period === 'Semi-annual') {
     return (

--- a/src/views/Finances/components/SectionPages/BreakdownTable/BreakdownTable.tsx
+++ b/src/views/Finances/components/SectionPages/BreakdownTable/BreakdownTable.tsx
@@ -1,6 +1,4 @@
-import styled from '@emotion/styled';
-import lightTheme from '@ses/styles/theme/themes';
-import React from 'react';
+import { styled } from '@mui/material';
 import type { Filter, ResetFilter } from '@/components/FiltersBundle/types';
 import BreakdownTableFinances from '../../BreakdownTableFinances/BreakdownTableFinances';
 import FinancesTable from '../../FinancesTable/FinancesTable';
@@ -64,33 +62,36 @@ const BreakdownTable: React.FC<Props> = ({
 
 export default BreakdownTable;
 
-const TableHeader = styled.div({
+const TableHeader = styled('div')(({ theme }) => ({
   marginTop: 24,
-  [lightTheme.breakpoints.up('tablet_768')]: {
+
+  [theme.breakpoints.up('tablet_768')]: {
     display: 'flex',
     flexDirection: 'column',
   },
-});
+}));
 
-const TableWrapper = styled.div({
+const TableWrapper = styled('div')(({ theme }) => ({
   marginTop: 16,
   display: 'flex',
   flexDirection: 'column',
   gap: 16,
-  [lightTheme.breakpoints.up('tablet_768')]: {
+
+  [theme.breakpoints.up('tablet_768')]: {
     marginTop: 24,
   },
-});
+}));
 
-const MainContainer = styled.div({
+const MainContainer = styled('div')(({ theme }) => ({
   display: 'flex',
   flex: 1,
   flexDirection: 'column',
   marginTop: 40,
-  [lightTheme.breakpoints.up('desktop_1280')]: {
+
+  [theme.breakpoints.up('desktop_1280')]: {
     marginTop: 64,
   },
-});
+}));
 
 const SkeletonWrapper = styled('div')({
   marginTop: 24,


### PR DESCRIPTION
## Ticket
https://trello.com/c/wKFOsgsR/491-reskin-finances-breakdown-table

## Description
Updated the header of the breakdown table with the new styles

## What solved

- [X] Should update the header table (card+ text+values) in the monthly, quarterly, and annual periods for light/dark mode. Desktop resolutions.
- [X] Should update the header table (card+ text+values) in the annually and semi-annual periods for light/dark mode. Small resolutions. 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

