### PR TITLE
fix: update utilization percentage number UI

### DIFF
--- a/src/views/Finances/components/SectionPages/OverviewSection/BudgetUtilizationCard/BudgetUtilizationCard.tsx
+++ b/src/views/Finances/components/SectionPages/OverviewSection/BudgetUtilizationCard/BudgetUtilizationCard.tsx
@@ -18,7 +18,7 @@ const BudgetUtilizationCard: React.FC<QuarterCardProps> = ({ paymentsOnChain, bu
 
   const humanizedActuals = threeDigitsPrecisionHumanization(paymentsOnChain);
   const humanizedBudgetCap = threeDigitsPrecisionHumanization(budgetCap);
-  const percent = usLocalizedNumber(percentageRespectTo(paymentsOnChain, budgetCap), 0);
+  const percent = percentageRespectTo(paymentsOnChain, budgetCap);
 
   return (
     <CardContainer>
@@ -41,7 +41,18 @@ const BudgetUtilizationCard: React.FC<QuarterCardProps> = ({ paymentsOnChain, bu
       </PredictionWrapper>
       <Description>Budget Utilization</Description>
       <DividerCardChart />
-      <Percent isRightPartZero={budgetCap === 0}>{budgetCap === 0 ? '-- ' : percent}%</Percent>
+      <Percent isRightPartZero={budgetCap === 0}>
+        {budgetCap === 0
+          ? '-- '
+          : percent === 0
+          ? 0
+          : percent < 0.1
+          ? '<0.1'
+          : percent < 1
+          ? usLocalizedNumber(percent, 2)
+          : usLocalizedNumber(percent, 1)}
+        %
+      </Percent>
       <BarWrapper>
         <HorizontalBudgetBarStyled actuals={paymentsOnChain} prediction={0} budgetCap={budgetCap} />
       </BarWrapper>


### PR DESCRIPTION
## Ticket
https://trello.com/c/lHsgd1Nv/485-reskin-finances-main-section

## Description
Use the same % logic we use in pie chart legend in the budget utilization percentage

## What solved

- [X] Should add one decimal place to the budget utilization following this logic: > 1% -> then 1 decimal place, > 0 & <1% -> 2 decimal places, = 0 then just 0%.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
