### PR TITLE
[Reskin-485] Fix breadcrumb on first render

### DIFF
--- a/src/views/Finances/components/SectionPages/BreadcrumbYearNavigation.tsx
+++ b/src/views/Finances/components/SectionPages/BreadcrumbYearNavigation.tsx
@@ -22,6 +22,7 @@ const BreadcrumbYearNavigation: React.FC<BreadcrumbYearNavigationProps> = ({
   return (
     <Breadcrumb
       items={breakdownItems}
+      maxSegmentWidthMobile={76}
       rightContent={
         <RightContentContainer>
           <BudgetButton onClick={handleOpenModal}>


### PR DESCRIPTION
## Ticket
https://trello.com/c/lHsgd1Nv/485-reskin-finances-main-section

## Description
The breadcrumb segments where getting an incorrect with on first render, this is now fixed

## What solved

- [X] **Environment:** Dev **Browser:** Chrome **Resolution:** Desktop **Steps to Reproduce:** From the second level in the breadcrumb. E.g. Finances->MakerDao Legacy Budget. Clicking on the Finances item.  **Expected Output:** The Finances view in the first level should be displayed and the breadcrumb should change accordingly.  **Current Output:** The breadcrumb change shows only one letter a few seconds after the proper items in the breadcrumb are displayed. ** Visual Proof:** [finances_breadcrumb.mp4](https://trello.com/1/cards/666c0d967827b1fca927c6e6/attachments/66d194f29e4802e540c195fc/download/chrome_ddfXQnpKNq.mp4), [updating.mp4](https://trello.com/1/cards/666c0d967827b1fca927c6e6/attachments/66d1da97ce7530e56c7c3721/download/chrome_Z5LKVorVMt.mp4). **Order Execution:** Please, make sure to show all info in the breadcrumb properly when the user returns the previous Finances levels.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
