### PR TITLE
[Reskin-485] Fix single card display issue

### DIFF
--- a/src/views/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
+++ b/src/views/Finances/components/SectionPages/CardsNavigation/CardsNavigation.tsx
@@ -121,8 +121,18 @@ const ContainerCardsNavigation = styled('div')<{ showSwiper: boolean; isCompact:
       gap: 24,
     },
 
+    // if there is only one item, we need to show the item in just one column
+    ...(items === 1 && {
+      [theme.breakpoints.up('desktop_1024')]: {
+        '& > div:nth-of-type(1)': {
+          maxWidth: 'calc(33.333333% - 16px)',
+        },
+      },
+    }),
+
     [theme.breakpoints.up('desktop_1280')]: {
       gap: 32,
+
       ...(showSwiper
         ? {
             margin: isCompact ? '0 -8px 0 -16px' : '0 -8px',
@@ -133,6 +143,14 @@ const ContainerCardsNavigation = styled('div')<{ showSwiper: boolean; isCompact:
               maxWidth: `calc(100% / ${items} - ${Math.abs(32 / items - 32)}px)`,
             },
           }),
+
+      // if there is only one item, we need to show the item in just one column
+      ...(items === 1 && {
+        '& > div:nth-of-type(1)': {
+          maxWidth: 'calc(33.333333% - 21.333px)',
+          minWidth: 'calc(33.333333% - 21.333px)',
+        },
+      }),
     },
   })
 );


### PR DESCRIPTION
## Ticket
https://trello.com/c/lHsgd1Nv/485-reskin-finances-main-section

## Description
If there's only one card, then it should be displayed in one column without covering all the container width

## What solved

- [X] **Environment:** Dev**Browser:** Chrome **Resolution:** Desktop **Steps to Reproduce:** Finances->Atlas Immutable Budget->Sky. https://expenses-dev.makerdao.network/finances/immutable/SKY?year=2024. **Expected Output:** The navigation card should be displayed with the same width as the Budget Utilization card and aligned to the left. [design.png](https://trello.com/1/cards/666c0d967827b1fca927c6e6/attachments/66d1bffac53f70e9b95c911b/previews/66d1bffbc53f70e9b95c9332/download/image_2024-08-30_14-10-02.png) **Current Output:** One card is displayed across the width of the container with the elements aligned to the left side showing a big blank space.  ** Visual Proof:** [image.png](https://trello.com/1/cards/666c0d967827b1fca927c6e6/attachments/66d1877a9847177f336d29ae/previews/66d1877b9847177f336d2a83/download/image.png). **Order Execution:** Please, make sure to show one card as the design shows.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
