### PR TITLE
[Reskin-485] Fix legend overlap in pie chart

### DIFF
--- a/src/views/Finances/components/SectionPages/CardChartOverview/OverviewCardKeyDetailsBudget/DoughnutChartFinances/CardLegend.tsx
+++ b/src/views/Finances/components/SectionPages/CardChartOverview/OverviewCardKeyDetailsBudget/DoughnutChartFinances/CardLegend.tsx
@@ -4,7 +4,7 @@ import type { DoughnutSeries } from '@/views/Finances/utils/types';
 import ItemLegendDoughnut from './ItemLegendDoughnut';
 
 interface Props {
-  isCoreThirdLevel?: boolean;
+  isDeepLevel?: boolean;
   changeAlignment: boolean;
   doughnutSeriesData: DoughnutSeries[];
   toggleSeriesVisibility: (seriesName: string) => void;
@@ -14,7 +14,7 @@ interface Props {
 
 const CardLegend: React.FC<Props> = ({
   changeAlignment,
-  isCoreThirdLevel = true,
+  isDeepLevel = true,
   doughnutSeriesData,
   onLegendItemHover,
   onLegendItemLeave,
@@ -22,7 +22,7 @@ const CardLegend: React.FC<Props> = ({
 }) => {
   const sortedDoughnutSeries = sortDoughnutSeriesByValue(doughnutSeriesData);
   return (
-    <ContainerLegend isCoreThirdLevel={isCoreThirdLevel} changeAlignment={changeAlignment}>
+    <ContainerLegend isDeepLevel={isDeepLevel} changeAlignment={changeAlignment}>
       {sortedDoughnutSeries.map((data, index) => (
         <ItemLegendDoughnut
           key={index}
@@ -31,7 +31,7 @@ const CardLegend: React.FC<Props> = ({
           onLegendItemHover={onLegendItemHover}
           onLegendItemLeave={onLegendItemLeave}
           toggleSeriesVisibility={toggleSeriesVisibility}
-          isCoreThirdLevel={isCoreThirdLevel}
+          isDeepLevel={isDeepLevel}
         />
       ))}
     </ContainerLegend>
@@ -40,20 +40,20 @@ const CardLegend: React.FC<Props> = ({
 
 export default CardLegend;
 
-const ContainerLegend = styled('div')<{ isCoreThirdLevel: boolean; changeAlignment: boolean }>(
-  ({ theme, isCoreThirdLevel, changeAlignment }) => ({
+const ContainerLegend = styled('div')<{ isDeepLevel: boolean; changeAlignment: boolean }>(
+  ({ theme, isDeepLevel, changeAlignment }) => ({
     display: 'flex',
     flexDirection: 'column',
     flexWrap: 'wrap',
-    justifyContent: isCoreThirdLevel && changeAlignment ? 'flex-start' : changeAlignment ? 'flex-start' : 'center',
-    gap: isCoreThirdLevel ? 4 : 8,
+    justifyContent: isDeepLevel && changeAlignment ? 'flex-start' : changeAlignment ? 'flex-start' : 'center',
+    gap: isDeepLevel ? 4 : 8,
     maxWidth: '100%',
     maxHeight: 155,
 
     [theme.breakpoints.up('desktop_1280')]: {
       columnGap: 24,
-      rowGap: isCoreThirdLevel ? 10 : 8,
-      marginTop: isCoreThirdLevel ? 6 : 0,
+      rowGap: isDeepLevel ? 10 : 8,
+      marginTop: isDeepLevel ? 6 : 0,
     },
   })
 );

--- a/src/views/Finances/components/SectionPages/CardChartOverview/OverviewCardKeyDetailsBudget/DoughnutChartFinances/ItemLegendDoughnut.tsx
+++ b/src/views/Finances/components/SectionPages/CardChartOverview/OverviewCardKeyDetailsBudget/DoughnutChartFinances/ItemLegendDoughnut.tsx
@@ -4,7 +4,7 @@ import type { DoughnutSeries } from '@/views/Finances/utils/types';
 import { getShortCode } from '../../utils';
 
 interface Props {
-  isCoreThirdLevel?: boolean;
+  isDeepLevel?: boolean;
   changeAlignment: boolean;
   doughnutData: DoughnutSeries;
   toggleSeriesVisibility: (seriesName: string) => void;
@@ -14,7 +14,7 @@ interface Props {
 
 const ItemLegendDoughnut: React.FC<Props> = ({
   changeAlignment,
-  isCoreThirdLevel = true,
+  isDeepLevel = true,
   doughnutData,
   onLegendItemHover,
   onLegendItemLeave,
@@ -26,18 +26,18 @@ const ItemLegendDoughnut: React.FC<Props> = ({
     <LegendItem
       key={doughnutData.name}
       changeAlignment={changeAlignment}
-      isCoreThirdLevel={isCoreThirdLevel}
+      isDeepLevel={isDeepLevel}
       onClick={() => toggleSeriesVisibility(doughnutData.name)}
       onMouseEnter={() => onLegendItemHover(doughnutData.name)}
       onMouseLeave={() => onLegendItemLeave(doughnutData.name)}
     >
       <IconWithName>
         <LegendIcon backgroundColor={doughnutData.color || 'blue'} />
-        <NameOrCode isCoreThirdLevel={isCoreThirdLevel} className="name">
-          {isCoreThirdLevel ? getShortCode(doughnutData?.code || '') : doughnutData.name}
+        <NameOrCode isDeepLevel={isDeepLevel} className="name">
+          {isDeepLevel ? getShortCode(doughnutData?.code || '') : doughnutData.name}
         </NameOrCode>
       </IconWithName>
-      <ValueDescription isCoreThirdLevel={isCoreThirdLevel}>
+      <ValueDescription isDeepLevel={isDeepLevel}>
         <Percent className="percentage">{`(${
           doughnutData.percent === 0
             ? 0
@@ -59,10 +59,10 @@ const ItemLegendDoughnut: React.FC<Props> = ({
 
 export default ItemLegendDoughnut;
 
-const LegendItem = styled('div')<{ isCoreThirdLevel: boolean; changeAlignment: boolean }>(
-  ({ theme, isCoreThirdLevel, changeAlignment }) => ({
+const LegendItem = styled('div')<{ isDeepLevel: boolean; changeAlignment: boolean }>(
+  ({ theme, isDeepLevel, changeAlignment }) => ({
     display: 'flex',
-    flexDirection: isCoreThirdLevel ? 'row' : 'column',
+    flexDirection: isDeepLevel ? 'row' : 'column',
     gap: 2,
     fontSize: 12,
     fontFamily: 'Inter, sans-serif',
@@ -95,21 +95,21 @@ const LegendIcon = styled('div')<{ backgroundColor: string }>(({ backgroundColor
   borderRadius: '50%',
 }));
 
-const ValueDescription = styled('div')<{ isCoreThirdLevel: boolean }>(({ theme, isCoreThirdLevel }) => ({
+const ValueDescription = styled('div')<{ isDeepLevel: boolean }>(({ theme, isDeepLevel }) => ({
   fontSize: 12,
   fontWeight: 500,
-  lineHeight: isCoreThirdLevel ? '24px' : 'normal',
+  lineHeight: isDeepLevel ? '24px' : 'normal',
   display: 'flex',
-  marginLeft: isCoreThirdLevel ? 4 : 14,
-  ...(isCoreThirdLevel && {
+  marginLeft: isDeepLevel ? 4 : 14,
+  ...(isDeepLevel && {
     whiteSpace: 'revert',
     overflow: 'revert',
     textOverflow: 'revert',
   }),
 
   [theme.breakpoints.up('desktop_1280')]: {
-    fontSize: isCoreThirdLevel ? 12 : 14,
-    lineHeight: isCoreThirdLevel ? '15px' : 'normal',
+    fontSize: isDeepLevel ? 12 : 14,
+    lineHeight: isDeepLevel ? '15px' : 'normal',
   },
 }));
 
@@ -120,7 +120,7 @@ const IconWithName = styled('div')({
   alignItems: 'center',
 });
 
-const NameOrCode = styled('div')<{ isCoreThirdLevel: boolean }>(({ theme, isCoreThirdLevel }) => ({
+const NameOrCode = styled('div')<{ isDeepLevel: boolean }>(({ theme, isDeepLevel }) => ({
   color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
   fontSize: 12,
   fontWeight: 600,
@@ -128,11 +128,11 @@ const NameOrCode = styled('div')<{ isCoreThirdLevel: boolean }>(({ theme, isCore
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
-  width: isCoreThirdLevel ? 'fit-content' : 170,
+  width: isDeepLevel ? 'fit-content' : 170,
 
   [theme.breakpoints.up('desktop_1280')]: {
-    fontSize: isCoreThirdLevel ? 12 : 14,
-    lineHeight: isCoreThirdLevel ? '15px' : '24px',
+    fontSize: isDeepLevel ? 12 : 14,
+    lineHeight: isDeepLevel ? '15px' : '24px',
   },
 }));
 

--- a/src/views/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
+++ b/src/views/Finances/components/SectionPages/CardChartOverview/useCardChartOverview.tsx
@@ -245,20 +245,17 @@ export const useCardChartOverview = (
   const changeAlignment = numberItems > 4;
 
   const showSwiper = ((isTable || isDesk1024) && numberItems >= 4) || (isDesk1280 && numberItems >= 10);
+  const isDeepLevel = doughnutSeriesData.length > 6;
 
-  const numberSliderPerLevel = isTable
-    ? numberItems >= 4 && levelNumber < 3
-      ? 3
-      : 5
-    : isDesk1024
-    ? numberItems >= 4 && levelNumber < 3
-      ? 3
-      : 5
-    : isDesk1280
-    ? numberItems >= 10
-      ? 12
-      : 5
-    : 5;
+  const numberSliderPerLevel = (() => {
+    if (isTable || isDesk1024) {
+      return isDeepLevel ? 5 : 3;
+    }
+    if (isDesk1280) {
+      return numberItems >= 10 ? 12 : 5;
+    }
+    return 5;
+  })();
 
   return {
     paymentsOnChain: isHasSubLevels ? metric.paymentsOnChain : budgetWithNotChildren.paymentsOnChain,

--- a/src/views/Finances/components/SectionPages/OverviewSection/UtilizationChart/DesktopChart/DesktopChart.tsx
+++ b/src/views/Finances/components/SectionPages/OverviewSection/UtilizationChart/DesktopChart/DesktopChart.tsx
@@ -288,7 +288,7 @@ const DesktopChart: React.FC<DesktopChartProps> = ({
   }
 
   return (
-    <Container isCoreThirdLevel={isDeepLevel}>
+    <Container isDeepLevel={isDeepLevel}>
       <ContainerChart>
         <ReactECharts
           ref={chartRef}
@@ -305,7 +305,7 @@ const DesktopChart: React.FC<DesktopChartProps> = ({
         </ContainerDaiIcon>
       </ContainerChart>
       {showSwiper ? (
-        <SwiperWrapper isCoreThirdLevel={isDeepLevel} numberSliderPerLevel={numberSliderPerLevel}>
+        <SwiperWrapper isDeepLevel={isDeepLevel} numberSliderPerLevel={numberSliderPerLevel}>
           <Swiper
             direction="horizontal"
             ref={ref}
@@ -314,11 +314,7 @@ const DesktopChart: React.FC<DesktopChartProps> = ({
             pagination={true}
             {...swiperOptions}
           >
-            <ContainerLegend
-              isCoreThirdLevel={isDeepLevel}
-              changeAlignment={changeAlignment}
-              numberSlider={numberSlider}
-            >
+            <ContainerLegend isDeepLevel={isDeepLevel} changeAlignment={changeAlignment} numberSlider={numberSlider}>
               {Array.from(doughnutSeriesChunks.entries()).map(([index, dataChunk]) => (
                 <SwiperSlide key={index}>
                   <CardLegend
@@ -328,7 +324,7 @@ const DesktopChart: React.FC<DesktopChartProps> = ({
                     toggleSeriesVisibility={toggleSeriesVisibility}
                     onLegendItemHover={onLegendItemHover}
                     onLegendItemLeave={onLegendItemLeave}
-                    isCoreThirdLevel={isDeepLevel}
+                    isDeepLevel={isDeepLevel}
                   />
                 </SwiperSlide>
               ))}
@@ -343,7 +339,7 @@ const DesktopChart: React.FC<DesktopChartProps> = ({
             toggleSeriesVisibility={toggleSeriesVisibility}
             onLegendItemHover={onLegendItemHover}
             onLegendItemLeave={onLegendItemLeave}
-            isCoreThirdLevel={isDeepLevel}
+            isDeepLevel={isDeepLevel}
           />
         </ContainerLegendNotSwiper>
       )}
@@ -353,7 +349,7 @@ const DesktopChart: React.FC<DesktopChartProps> = ({
 
 export default DesktopChart;
 
-const Container = styled('div')<{ isCoreThirdLevel: boolean }>(({ theme, isCoreThirdLevel }) => ({
+const Container = styled('div')<{ isDeepLevel: boolean }>(({ theme, isDeepLevel }) => ({
   display: 'none',
 
   [theme.breakpoints.up('tablet_768')]: {
@@ -369,7 +365,7 @@ const Container = styled('div')<{ isCoreThirdLevel: boolean }>(({ theme, isCoreT
   },
 
   [theme.breakpoints.up('desktop_1280')]: {
-    gap: isCoreThirdLevel ? 40 : 32,
+    gap: isDeepLevel ? 40 : 32,
   },
 }));
 
@@ -389,14 +385,14 @@ const ContainerChart = styled('div')(({ theme }) => ({
   },
 }));
 
-const ContainerLegend = styled('div')<{ isCoreThirdLevel: boolean; changeAlignment: boolean; numberSlider: number }>(
-  ({ theme, isCoreThirdLevel, changeAlignment, numberSlider }) => ({
+const ContainerLegend = styled('div')<{ isDeepLevel: boolean; changeAlignment: boolean; numberSlider: number }>(
+  ({ theme, isDeepLevel, changeAlignment, numberSlider }) => ({
     display: 'flex',
-    flex: isCoreThirdLevel && numberSlider >= 2 ? 1 : 'none',
+    flex: isDeepLevel && numberSlider >= 2 ? 1 : 'none',
     flexDirection: 'column',
     flexWrap: 'wrap',
-    justifyContent: isCoreThirdLevel && changeAlignment ? 'flex-start' : changeAlignment ? 'flex-start' : 'center',
-    gap: isCoreThirdLevel ? 16 : 14,
+    justifyContent: isDeepLevel && changeAlignment ? 'flex-start' : changeAlignment ? 'flex-start' : 'center',
+    gap: isDeepLevel ? 16 : 14,
     maxWidth: '100%',
     position: 'relative',
 
@@ -416,8 +412,8 @@ const ContainerLegendNotSwiper = styled('div')(() => ({
   position: 'relative',
 }));
 
-const SwiperWrapper = styled('div')<{ isCoreThirdLevel: boolean; numberSliderPerLevel: number }>(
-  ({ theme, isCoreThirdLevel, numberSliderPerLevel }) => ({
+const SwiperWrapper = styled('div')<{ isDeepLevel: boolean; numberSliderPerLevel: number }>(
+  ({ theme, isDeepLevel, numberSliderPerLevel }) => ({
     display: 'none',
 
     [theme.breakpoints.up('tablet_768')]: {
@@ -427,7 +423,7 @@ const SwiperWrapper = styled('div')<{ isCoreThirdLevel: boolean; numberSliderPer
     },
 
     [theme.breakpoints.up('desktop_1024')]: {
-      marginTop: isCoreThirdLevel ? 0 : 16,
+      marginTop: isDeepLevel ? 0 : 16,
       display: 'flex',
       width: 250,
       minWidth: 250,


### PR DESCRIPTION
## Ticket
https://trello.com/c/lHsgd1Nv/485-reskin-finances-main-section

## Description
The legend was overlapping with each other in some specific cases

## What solved

- [X] **Environment:** Dev **Browser:** Chrome **Resolution:** From1024 to 1280 **Steps to Reproduce:** Finances->Atlas Immutable Budget->Sky->Neutral tokenomics. Pie chart legend. https://expenses-dev.makerdao.network/finances/immutable/SKY/NTE?year=2024 **Expected Output:** The second column should be displayed properly. **Current Output:** One element of the second column is displayed along with the first column but this element is cut off. Navigating throughout the swiper the last part of the element is displayed with the rest of the elements overlapping on it ** Visual Proof:** [image.png](https://trello.com/1/cards/666c0d967827b1fca927c6e6/attachments/66d183f5cc73468416b12bbb/previews/66d183f6cc73468416b12c44/download/image.png), [image.png](https://trello.com/1/cards/666c0d967827b1fca927c6e6/attachments/66d18688e1a369877e290648/previews/66d18689e1a369877e2906b0/download/image.png). **Order Execution:** Please, make sure the elements of the second column are displayed properly.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
