### PR TITLE
fix: breakdown table filter

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/views/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/views/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -605,9 +605,14 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
 
   // handlers to change the period and metrics or reset those values to the default ones
   const handleSelectChangeMetrics = (value: string[]) => {
-    setActiveMetrics(value);
-    updateUrl(periodFilter, value);
+    if (value.length === 0) return; // we need at least one metric selected
+
+    // get the latest max amount of active metrics
+    const allowedMetrics = value.slice(value.length - maxAmountOfActiveMetrics);
+    setActiveMetrics(allowedMetrics);
+    updateUrl(periodFilter, allowedMetrics);
   };
+
   const handleResetMetrics = () => {
     if (isMobile) {
       setActiveMetrics(METRIC_FILTER_OPTIONS.slice(0, maxAmountOfActiveMetrics));


### PR DESCRIPTION
## Ticket
https://trello.com/c/wKFOsgsR/491-reskin-finances-breakdown-table

## Description
The filters of the breakdown table weren't allowed to change

## What solved

- [X] **Environment:** Dev **Browser:** Chrome **Resolution:** Mobile **Steps to Reproduce:**  Filters. Period: Semi-Annual, Changing the metrics. **Expected Output:** Only one metric should be selected. When a metric is selected the previous should be unselected and the metric should change the table header. **Current Output:** The previous metric is not unselected and the table header doesn't change with the new metric selected. ** Visual Proof:** [filter.mp4](https://trello.com/1/cards/666c1012a70c8ff7a0995373/attachments/66d59db7d6bc4b8a42a0394f/download/chrome_TiuN4wdBKd.mp4). **Order Execution:** Please, make sure that the filter works properly.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
