### PR TITLE
 [Fix-490] Add the placeholder when there is not image provide for the API

### DIFF
--- a/src/views/Finances/components/BreakdownChartSection/BreakdownChart/LegendBreakDownChart/LegendBreakDownChart.tsx
+++ b/src/views/Finances/components/BreakdownChartSection/BreakdownChart/LegendBreakDownChart/LegendBreakDownChart.tsx
@@ -75,7 +75,6 @@ const LegendBreakDownChart: FC<Props> = ({
       <SimpleContainer>
         <SimpleContainerSeries showLessGap={series.length === 7}>
           {series.map((element) => {
-            console.log(element.data);
             const value = element.data.reduce((prev, current) => prev + (current.value ?? 0), 0);
             return (
               <LegendItemBreakDownChart

--- a/src/views/Finances/components/ReservesWaterfallFilters/BudgetItem.tsx
+++ b/src/views/Finances/components/ReservesWaterfallFilters/BudgetItem.tsx
@@ -12,7 +12,7 @@ interface Props {
 const BudgetItem: React.FC<Props> = ({ image, label, isActive }) => (
   <Container>
     <ImageContainer>
-      <Image src={image ?? ''} alt="Budget Icon" fill={true} unoptimized />
+      <Image src={image || '/assets/img/default-icon-cards-budget.svg'} alt="Budget Icon" unoptimized fill />
     </ImageContainer>
     <Title isActive={isActive}>{label}</Title>
   </Container>


### PR DESCRIPTION
## Ticket
https://trello.com/c/9OSVjQNT/490-reskin-finances-reserves-chart


##  What Solves
- [X] The filter should display the icon with the category name.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
