### PR TITLE
Fix breakdown filter reset option

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/components/FiltersBundle/useFiltersBundle.ts
+++ b/src/components/FiltersBundle/useFiltersBundle.ts
@@ -21,7 +21,7 @@ export const breakpointsOrder: (keyof typeof breakpoints)[] = [
 ];
 
 export default function useFiltersBundle({ filters, order, asPopover }: Props) {
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'), { defaultMatches: true });
   const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.between('tablet_768', 'desktop_1024'));
   const isDesktop1024 = useMediaQuery((theme: Theme) => theme.breakpoints.between('desktop_1024', 'desktop_1280'));
   const isDesktop1280 = useMediaQuery((theme: Theme) => theme.breakpoints.between('desktop_1280', 'desktop_1440'));

--- a/src/views/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/views/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -648,7 +648,9 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
     JSON.stringify(METRIC_FILTER_OPTIONS.slice(0, maxAmountOfActiveMetrics).sort());
 
   const resetFilters: ResetFilter = {
-    canReset: metricsMatch && (isMobile ? selectedGranularity === 'semiAnnual' : selectedGranularity === 'quarterly'),
+    canReset: !(
+      metricsMatch && (isMobile ? selectedGranularity === 'semiAnnual' : selectedGranularity === 'quarterly')
+    ),
     onReset: handleResetMetrics,
   };
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/wKFOsgsR/491-reskin-finances-breakdown-table

## Description
Fixed the reset filter button in the breakdown table

## What solved

- [X] **Environment:** Dev **Browser:** Chrome **Resolution:** All **Steps to Reproduce:** Filters, Reset option.  **Expected Output:** By default the period filter should be Quarterly and the Reset option should be disabled. **Current Output:** By default the Reset option is enabled. Changing to Annually the Reset option is then disabled.  ** Visual Proof:** [reset_option.mp4](https://trello.com/1/cards/666c1012a70c8ff7a0995373/attachments/66d6cc6d63a91fd9b70b7598/download/chrome_4U6neMeSb7.mp4), [mobile.pm4](https://trello.com/1/cards/666c1012a70c8ff7a0995373/attachments/66d6fe52eff6706b94ce3931/download/chrome_44OuMbW1nV.mp4). **Order Execution:** Please, set the filter as the Legacy Dashboard shows.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
