### PR TITLE
[Reskin-585] Apply dark mode theme as default theme

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -88,7 +88,7 @@ MyApp.getInitialProps = async ({ ctx }: { ctx: NextPageContext }) => {
     allowsThemeTracking: false,
     allowsTimestampTracking: false,
     allowsAnalyticsTracking: false,
-    themeModeCookie: 'light',
+    themeModeCookie: 'dark',
   };
 
   if (ctx.req?.headers.cookie) {
@@ -98,11 +98,11 @@ MyApp.getInitialProps = async ({ ctx }: { ctx: NextPageContext }) => {
       allowsThemeTracking: Boolean(cookiesParsed?.themeTracking),
       allowsTimestampTracking: Boolean(cookiesParsed?.timestampTracking),
       allowsAnalyticsTracking: Boolean(cookiesParsed?.analyticsTracking),
-      themeModeCookie: cookiesParsed?.themeModeCookie || 'light',
+      themeModeCookie: cookiesParsed?.themeModeCookie || 'dark',
     };
   }
 
-  const isLight = cookiesObject?.allowsThemeTracking ? cookiesObject.themeModeCookie === 'light' : true;
+  const isLight = cookiesObject?.allowsThemeTracking ? cookiesObject.themeModeCookie === 'light' : false;
   return {
     isLight,
     cookiesObject,

--- a/src/stories/containers/CookiesPolicy/useCookiesPolicyBanner.ts
+++ b/src/stories/containers/CookiesPolicy/useCookiesPolicyBanner.ts
@@ -71,7 +71,7 @@ export const useCookiesPolicyBanner = ({ cookiesObject }: Props) => {
   );
 
   const setThemeModeCookie = useCallback(() => {
-    const newThemeMode = cookies.themeModeCookie ? cookies.themeModeCookie : 'light';
+    const newThemeMode = cookies.themeModeCookie ? cookies.themeModeCookie : 'dark';
     setCookie('themeModeCookie', newThemeMode, {
       expires: daysToExpire(),
       path: '/',


### PR DESCRIPTION
## Ticket
https://trello.com/c/1s6MFOqA/585-apply-the-dark-mode-as-default-theme

## Description
Now the dark theme is the default theme

## What solved

- [X] Should change the dark mode as default theme.
- [X] Should update the theme icons accordingly.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook
