### PR TITLE
Fix the filter in breakdown table

### DIFF
--- a/src/views/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
+++ b/src/views/Finances/components/SectionPages/BreakdownTable/useBreakdownTable.tsx
@@ -653,7 +653,6 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
     ),
     onReset: handleResetMetrics,
   };
-
   const metricSelectId = useId();
   const granularitySelectId = useId();
   const filters: Filter[] = [
@@ -661,7 +660,13 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
       id: metricSelectId,
       type: 'select',
       options: METRIC_FILTER_OPTIONS.map((filter) => ({
-        label: filter,
+        label: isTable
+          ? filter === 'Net Protocol Outflow'
+            ? 'Prtcol Outfl'
+            : filter === 'Net Expenses On-Chain'
+            ? 'Net On-Chain'
+            : filter
+          : filter,
         value: filter,
       })),
       label: 'Metrics',
@@ -669,7 +674,7 @@ export const useBreakdownTable = (year: string, budgets: Budget[], allBudgets: B
       multiple: true,
       onChange: (value) => handleSelectChangeMetrics(value as string[]),
       widthStyles: {
-        width: 140,
+        width: 'fit-content',
         menuWidth: 220,
       },
     },


### PR DESCRIPTION
## Ticket
https://trello.com/c/wKFOsgsR/491-reskin-finances-breakdown-table

## What solved
- [X] Metrics filter. Selecting one metric (e.g. Net Protocol Outflow). The full metric name should be displayed in the filter. The part of the name is displayed followed by dots. 

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have performed a self-review of my chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if applicable)
