### PR TITLE
Add the default state of filters for breakdown and waterfall chart

### DIFF
--- a/src/views/Finances/components/BreakdownChartSection/BreakdownChartSection.tsx
+++ b/src/views/Finances/components/BreakdownChartSection/BreakdownChartSection.tsx
@@ -53,7 +53,7 @@ const BreakdownChartSection: React.FC<BreakdownChartSectionProps> = ({
 
       <FilterContainer>
         <FiltersBundle
-          asPopover={['tablet_768', 'desktop']}
+          asPopover={[]}
           filters={filters}
           resetFilters={{
             canReset,

--- a/src/views/Finances/components/SectionPages/ReservesWaterfallChartSection/ReservesWaterfallChartSection.tsx
+++ b/src/views/Finances/components/SectionPages/ReservesWaterfallChartSection/ReservesWaterfallChartSection.tsx
@@ -55,8 +55,8 @@ const ReservesWaterfallChartSection: React.FC<Props> = ({
       />
       <FilterContainer>
         <FiltersBundle
+          asPopover={[]}
           heightForScroll
-          asPopover={['tablet_768', 'desktop']}
           filters={filters}
           resetFilters={{
             canReset,

--- a/src/views/Finances/components/SectionPages/ReservesWaterfallChartSection/useReservesWaterfallChart.tsx
+++ b/src/views/Finances/components/SectionPages/ReservesWaterfallChartSection/useReservesWaterfallChart.tsx
@@ -176,7 +176,6 @@ export const useReservesWaterfallChart = (codePath: string, budgets: Budget[], a
       withAll: false,
       widthStyles: {
         width: 'fit-content',
-        menuWidth: 350,
       },
     },
     {
@@ -201,6 +200,10 @@ export const useReservesWaterfallChart = (codePath: string, budgets: Budget[], a
             alignItems: 'center',
           },
         }),
+      widthStyles: {
+        width: 'fit-content',
+        menuWidth: 350,
+      },
     },
   ];
 


### PR DESCRIPTION

## Ticket
https://trello.com/c/SCfXrMha/593-show-selected-filters



## What solved

- [X] Should update the filters in the Reserves Chart section.
- [X] Should update the filters in the Break Down  Chart section.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have performed a self-review of my own chromatic changes
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have checked my code and corrected any misspellings
- [ ] I have removed any unnecessary console messages
- [ ] I have removed any commented code
- [ ] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
