### PR TITLE
[BSS] Fix navigate till the latest budget statement only

### DIFF
--- a/src/core/hooks/useBudgetStatementPager.ts
+++ b/src/core/hooks/useBudgetStatementPager.ts
@@ -51,11 +51,7 @@ const useBudgetStatementPager = (element: WithBudgetStatement, options?: BudgetS
 
   useEffect(() => {
     const snapshotLimit = options?.latestSnapshotPeriod?.latest?.startOf('month');
-    const limit = getLastMonthWithActualOrForecast(element.budgetStatements)
-      .plus({
-        month: 1,
-      })
-      .startOf('month');
+    const limit = getLastMonthWithActualOrForecast(element.budgetStatements).startOf('month');
     const actualMonth = DateTime.utc().startOf('month');
 
     const mostRecentMonth = snapshotLimit ? (snapshotLimit > limit ? snapshotLimit : limit) : limit;


### PR DESCRIPTION
## Ticket
https://trello.com/c/j7lqyGlI/463-bss-0-global-requirements-for-bsss

## Description
Allow to navigate till the latest budget statement with data instead of a +1 month

## What solved

- [X] **Environment:** Dev **Browser:** Chrome **Resolution:** All **Steps to Reproduce:** Finances-> MakerDAO Legacy Budget. Budget Statements section: Clicking on the Recognized-Delegates- Aug 2024 report. https://expenses-dev.makerdao.network/finances/legacy?year=2024 **Expected Output:** It should redirect to its Budget Statements page in Aug 2024.  **Current Output:** It redirects to the proper page but in April 2023. Navigating to the previous month March 2023, the next arrow gets disabled  ** Visual Proof:** [AD.mp4](https://trello.com/1/cards/665858742d01ca775b41071f/attachments/66d8391b5edf724e1e5565cf/download/chrome_hi37ebKg8T.mp4) **Order Execution:** Please, make sure to show the proper behavior.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
