### PR TITLE
[QA-595] Add the categories in the all tab

### DIFF
--- a/src/views/Home/components/Contributors/ContributorsItem.tsx
+++ b/src/views/Home/components/Contributors/ContributorsItem.tsx
@@ -113,7 +113,20 @@ const ContributorsItem: FC<Props> = ({ contributor, className, hasDefaultColors 
         ) : textDefault ? (
           <>
             <ScopesDesk>
-              {contributor?.scopes?.length > 1 ? (
+              {contributor.type === ResourceType.CoreUnit ? (
+                // New code for Core Unit categories
+                <ContainerCategories>
+                  {contributor?.category?.length > 2 ? (
+                    <GroupScopesContributors items={contributor.category as TeamCategory[]} />
+                  ) : contributor?.category?.length === 0 || contributor.category === null ? (
+                    <PlaceHolderEcosystemActor />
+                  ) : (
+                    contributor?.category?.map((item, index) => (
+                      <CategoryChip category={item as TeamCategory} key={index} />
+                    ))
+                  )}
+                </ContainerCategories>
+              ) : contributor?.scopes?.length > 1 ? (
                 <GroupScopesContributors items={contributor.scopes} />
               ) : contributor?.scopes?.length === 0 || contributor.scopes === null ? (
                 <PlaceHolderEcosystemActor />
@@ -247,6 +260,7 @@ const ScopesDesk = styled('div')(({ theme }) => ({
   display: 'none',
   [theme.breakpoints.up('desktop_1024')]: {
     display: 'flex',
+    minWidth: 90,
   },
 }));
 const RoleDesk = styled('div')(({ theme }) => ({
@@ -259,7 +273,12 @@ const RoleDesk = styled('div')(({ theme }) => ({
   },
 }));
 
-const DateUpdated = styled('div')({});
+const DateUpdated = styled('div')(({ theme }) => ({
+  [theme.breakpoints.up('desktop_1024')]: {
+    display: 'flex',
+    minWidth: 120,
+  },
+}));
 const ArrowContainerDesk = styled('div')(({ theme }) => ({
   display: 'none',
   [theme.breakpoints.up('desktop_1024')]: {


### PR DESCRIPTION
## Ticket
https://trello.com/c/HsoaPE5o/595-fix-all-tab-in-the-contributors-section


## What solved
- [X] Should the Ecosystem Actors label be displayed for ecosystem actors?
- [X] Should the Core Units label be displayed for core units?

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
