### PR TITLE
[Reskin-611] Fix filters restoration in breakdown chart

### DIFF
--- a/src/views/Finances/components/BreakdownChartSection/useBreakdownChart.ts
+++ b/src/views/Finances/components/BreakdownChartSection/useBreakdownChart.ts
@@ -19,6 +19,7 @@ import type { EChartsOption } from 'echarts-for-react';
 const DEFAULT_METRIC: AnalyticMetric = 'Budget';
 const DEFAULT_GRANULARITY: AnalyticGranularity = 'monthly';
 const METRIC_FILTER_OPTIONS = ['Budget', 'Forecast', 'Net Protocol Outflow', 'Net Expenses On-Chain', 'Actuals'];
+
 const useBreakdownChart = (budgets: Budget[], year: string, codePath: string, allBudgets: Budget[]) => {
   const router = useRouter();
   const { isLight } = useThemeContext();
@@ -231,7 +232,7 @@ const useBreakdownChart = (budgets: Budget[], year: string, codePath: string, al
             ? 'Net On-Chain'
             : filter
           : filter,
-        value: filter,
+        value: getKeyMetricBreakDownChart(filter),
       })),
       withAll: false,
       widthStyles: {


### PR DESCRIPTION
## Ticket
https://trello.com/c/rRucpp5k/611-fix-the-deeplink-applied-in-breakdown-chart

## What solved

- [X] Should apply the expected deeplink.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
