### PR TITLE
[Reskin-611] Keep and restore filter status in the URL

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,7 +1,19 @@
+import { CURRENT_ENVIRONMENT } from '@/config/endpoints';
 import { BASE_URL } from '@/config/routes';
 import type { MetadataRoute } from 'next';
 
 export default function robots(): MetadataRoute.Robots {
+  if (CURRENT_ENVIRONMENT !== 'production') {
+    return {
+      rules: [
+        {
+          userAgent: '*',
+          disallow: '*',
+        },
+      ],
+    };
+  }
+
   return {
     rules: [
       {

--- a/src/components/FiltersBundle/types.ts
+++ b/src/components/FiltersBundle/types.ts
@@ -87,7 +87,6 @@ export interface CumulativeFilter extends GenericFilter {
   options?: RadioOption[];
   cumulativeType: 'absolute' | 'relative';
   isCumulative: boolean;
-  onChange: () => void;
   handleChangeCumulativeType: (value: 'absolute' | 'relative') => void;
   handleToggleCumulative: () => void;
   customOptionsRender?: (option: RadioOption, isActive: boolean, theme?: Theme) => ReactNode;

--- a/src/core/hooks/useRestorationFromUrlState.ts
+++ b/src/core/hooks/useRestorationFromUrlState.ts
@@ -40,7 +40,6 @@ const useRestorationFromUrlState = (
 ) => {
   const router = useRouter();
   const [urlState, setUrlState] = useState<DecodedUrlState>({});
-  console.log('urlState' + sectionKey, urlState);
 
   const [initialized, setInitialized] = useState<boolean>(false);
 
@@ -78,7 +77,6 @@ const useRestorationFromUrlState = (
               [ENABLED_SECTIONS_KEY]: availableKeys,
               ...queries,
             },
-            // hash: router.
           },
           undefined,
           {

--- a/src/core/hooks/useRestorationFromUrlState.ts
+++ b/src/core/hooks/useRestorationFromUrlState.ts
@@ -1,0 +1,129 @@
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useState } from 'react';
+import type { ParsedUrlQuery } from 'querystring';
+
+export interface DecodedUrlState {
+  [key: string]: {
+    [paramKey: string]: string[] | undefined;
+  };
+}
+
+const ENABLED_SECTIONS_KEY = 'availableKeys';
+
+export const buildInMemoryUrlState = (query: ParsedUrlQuery): DecodedUrlState => {
+  const availableKeys =
+    typeof query[ENABLED_SECTIONS_KEY] === 'string'
+      ? query[ENABLED_SECTIONS_KEY].split(',')
+      : query[ENABLED_SECTIONS_KEY] ?? [];
+
+  const state: DecodedUrlState = {};
+
+  availableKeys.forEach((sectionKey) => {
+    state[sectionKey] = {};
+
+    Object.keys(query).forEach((queryKey) => {
+      // all the params of each section have the "section key" appended to end of its name to prevent collisions
+      if (queryKey.endsWith(sectionKey)) {
+        const paramKey = queryKey.replace(sectionKey, '');
+        state[sectionKey][paramKey] =
+          typeof query[queryKey] === 'string' ? query[queryKey].split(',') : query[queryKey];
+      }
+    });
+  });
+
+  return state;
+};
+
+const useRestorationFromUrlState = (
+  sectionKey: string,
+  onInit?: (state: DecodedUrlState[keyof DecodedUrlState]) => void
+) => {
+  const router = useRouter();
+  const [urlState, setUrlState] = useState<DecodedUrlState>({});
+  console.log('urlState' + sectionKey, urlState);
+
+  const [initialized, setInitialized] = useState<boolean>(false);
+
+  // initialize state from url state and run onInit event
+  useEffect(() => {
+    if (initialized) return;
+    setInitialized(true);
+    const decodedUrlState = buildInMemoryUrlState(router.query);
+    onInit?.(decodedUrlState[sectionKey]);
+  }, [initialized, onInit, router.query, sectionKey]);
+
+  // keep update in sync with url state
+  useEffect(() => {
+    const decodedUrlState = buildInMemoryUrlState(router.query);
+    setUrlState(decodedUrlState);
+  }, [router.query]);
+
+  const updateUrlFromState = useCallback(
+    (state: DecodedUrlState) => {
+      const availableKeys = Object.keys(state);
+
+      const queries: ParsedUrlQuery = {};
+
+      availableKeys.forEach((sectionKey) => {
+        Object.keys(state[sectionKey]).forEach((paramKey) => {
+          queries[`${paramKey}${sectionKey}`] = state[sectionKey][paramKey];
+        });
+      });
+
+      router
+        .replace(
+          {
+            query: {
+              ...router.query,
+              [ENABLED_SECTIONS_KEY]: availableKeys,
+              ...queries,
+            },
+            // hash: router.
+          },
+          undefined,
+          {
+            shallow: true,
+          }
+        )
+        .catch((error) => {
+          if (!error.cancelled) {
+            throw error;
+          }
+        });
+    },
+    [router]
+  );
+
+  const handleStateUpdate = useCallback(
+    (sectionKey: string, data: { [paramKey: string]: string | string[] }) => {
+      setUrlState((prevState) => {
+        const newState = { ...prevState };
+        if (!newState[sectionKey]) {
+          newState[sectionKey] = {};
+        }
+        Object.keys(data).forEach((paramKey) => {
+          newState[sectionKey][paramKey] = typeof data[paramKey] === 'string' ? [data[paramKey]] : data[paramKey];
+        });
+
+        updateUrlFromState(newState);
+        return newState;
+      });
+    },
+    [updateUrlFromState]
+  );
+
+  const handleCurrentSectionStateUpdate = useCallback(
+    (data: { [paramKey: string]: string | string[] }) => {
+      handleStateUpdate(sectionKey, data);
+    },
+    [handleStateUpdate, sectionKey]
+  );
+
+  return {
+    urlState,
+    handleStateUpdate,
+    handleCurrentSectionStateUpdate,
+  };
+};
+
+export default useRestorationFromUrlState;

--- a/src/views/Finances/components/BreakdownChartSection/useBreakdownChart.ts
+++ b/src/views/Finances/components/BreakdownChartSection/useBreakdownChart.ts
@@ -1,10 +1,11 @@
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useThemeContext } from '@ses/core/context/ThemeContext';
 import lightTheme from '@ses/styles/theme/themes';
-import { useRouter } from 'next/router';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import useSWRImmutable from 'swr/immutable';
 import type { Filter } from '@/components/FiltersBundle/types';
+import useRestorationFromUrlState from '@/core/hooks/useRestorationFromUrlState';
+import { FinancesSectionId } from '../../types';
 import { getBudgetsAnalytics, getKeyMetricBreakDownChart } from '../../utils/utils';
 import { getBarWidth, parseAnalyticsToSeriesBreakDownChart, setBorderRadiusForSeries } from './utils';
 import type { SelectItem } from '@ses/components/SingleItemSelect/SingleItemSelect';
@@ -21,40 +22,11 @@ const DEFAULT_GRANULARITY: AnalyticGranularity = 'monthly';
 const METRIC_FILTER_OPTIONS = ['Budget', 'Forecast', 'Net Protocol Outflow', 'Net Expenses On-Chain', 'Actuals'];
 
 const useBreakdownChart = (budgets: Budget[], year: string, codePath: string, allBudgets: Budget[]) => {
-  const router = useRouter();
   const { isLight } = useThemeContext();
   const isMobile = useMediaQuery(lightTheme.breakpoints.down('tablet_768'));
   const isTablet = useMediaQuery(lightTheme.breakpoints.between('tablet_768', 'desktop_1024'));
   const isDesktop1024 = useMediaQuery(lightTheme.breakpoints.between('desktop_1024', 'desktop_1280'));
   const isDesktop1280 = useMediaQuery(lightTheme.breakpoints.up('desktop_1280'));
-
-  const metricItems: SelectItem<AnalyticMetric>[] = useMemo(
-    () => [
-      {
-        label: 'Budget',
-        value: 'Budget',
-      },
-      {
-        label: 'Forecast',
-        value: 'Forecast',
-      },
-      {
-        label: 'Net Protocol Outflow',
-        value: 'ProtocolNetOutflow',
-        labelWhenSelected: isMobile || isTablet ? 'Prtcol Outfl' : 'Protocol Outflow',
-      },
-      {
-        label: 'Net Expenses On-Chain',
-        value: 'PaymentsOnChain',
-        labelWhenSelected: 'Net On-Chain',
-      },
-      {
-        label: 'Actuals',
-        value: 'Actuals',
-      },
-    ],
-    [isMobile, isTablet]
-  );
 
   const granularityItems: SelectItem<AnalyticGranularity>[] = useMemo(
     () => [
@@ -82,62 +54,17 @@ const useBreakdownChart = (budgets: Budget[], year: string, codePath: string, al
   const [selectedMetric, setSelectedMetric] = useState<AnalyticMetric>(DEFAULT_METRIC);
   const [selectedGranularity, setSelectedGranularity] = useState<AnalyticGranularity>(DEFAULT_GRANULARITY);
 
-  // update filters from url params
-  const [appliedUrlFilters, setAppliedUrlFilters] = useState<boolean>(false);
-  useEffect(() => {
-    if (appliedUrlFilters) return;
-    setAppliedUrlFilters(true); // prevent from applying the filters twice when the component is re-rendered
-    if (router.asPath.includes('#breakdown-chart')) {
-      const metricInURL = router.query.metric;
-      const granularityInURL = router.query.period;
-
-      // update metric if it is valid
-      if (
-        typeof metricInURL === 'string' &&
-        metricItems.map((item) => item.value).includes(metricInURL as AnalyticMetric)
-      ) {
-        setSelectedMetric(metricInURL as AnalyticMetric);
-      }
-
-      // update granularity if it is valid
-      if (
-        typeof granularityInURL === 'string' &&
-        granularityItems.map((item) => item.value).includes(granularityInURL as AnalyticGranularity)
-      ) {
-        setSelectedGranularity(granularityInURL as AnalyticGranularity);
-      }
+  const { handleCurrentSectionStateUpdate } = useRestorationFromUrlState(FinancesSectionId.BREAKDOWN_CHART, (state) => {
+    if (state?.metric && state.metric.length > 0) {
+      setSelectedMetric(state.metric[0] as AnalyticMetric);
     }
-  }, [appliedUrlFilters, granularityItems, metricItems, router]);
+    if (state?.granularity && state.granularity.length > 0) {
+      setSelectedGranularity(state.granularity[0] as AnalyticGranularity);
+    }
+  });
 
   const refBreakDownChart = useRef<EChartsOption | null>(null);
   const barWidth = getBarWidth(isMobile, isTablet, isDesktop1024, isDesktop1280, selectedGranularity);
-
-  const updateUrl = useCallback(
-    (metric: AnalyticMetric, granularity: AnalyticGranularity) => {
-      router
-        .replace(
-          {
-            query: {
-              path: router.query.path,
-              year,
-              metric,
-              period: granularity,
-            },
-            hash: 'breakdown-chart',
-          },
-          undefined,
-          {
-            shallow: true,
-          }
-        )
-        .catch((error) => {
-          if (!error.cancelled) {
-            throw error;
-          }
-        });
-    },
-    [router, year]
-  );
 
   const handleChangeSwitch = () => {
     if (!isChecked && inactiveSeries.length > 0) {
@@ -220,10 +147,9 @@ const useBreakdownChart = (budgets: Budget[], year: string, codePath: string, al
       selected: selectedMetric,
       multiple: false,
       onChange: (value: string | number | (string | number)[]) => {
-        updateUrl(value as AnalyticMetric, selectedGranularity);
+        handleCurrentSectionStateUpdate({ metric: value as string });
         setSelectedMetric(value as AnalyticMetric);
       },
-
       options: METRIC_FILTER_OPTIONS.map((filter) => ({
         label: isTablet
           ? filter === 'Net Protocol Outflow'
@@ -247,7 +173,7 @@ const useBreakdownChart = (budgets: Budget[], year: string, codePath: string, al
       selected: selectedGranularity,
       multiple: false,
       onChange: (value: string | number | (string | number)[]) => {
-        updateUrl(selectedMetric, value as AnalyticGranularity);
+        handleCurrentSectionStateUpdate({ granularity: value as string });
         setSelectedGranularity(value as AnalyticGranularity);
       },
       options: granularityItems,
@@ -263,7 +189,10 @@ const useBreakdownChart = (budgets: Budget[], year: string, codePath: string, al
   const onReset = () => {
     setSelectedMetric(DEFAULT_METRIC);
     setSelectedGranularity(DEFAULT_GRANULARITY);
-    updateUrl(DEFAULT_METRIC, DEFAULT_GRANULARITY);
+    handleCurrentSectionStateUpdate({
+      metric: DEFAULT_METRIC,
+      granularity: DEFAULT_GRANULARITY,
+    });
   };
   // Show the toggle and scroll in the legend of the chart
   const showScrollAndToggle = isMobile ? series.length > 6 : series.length > 8;

--- a/src/views/Finances/components/ExpenseMetrics/useExpenseMetrics.tsx
+++ b/src/views/Finances/components/ExpenseMetrics/useExpenseMetrics.tsx
@@ -4,24 +4,41 @@ import { useRouter } from 'next/router';
 import { useMemo, useState } from 'react';
 import useSWRImmutable from 'swr/immutable';
 import type { Filter } from '@/components/FiltersBundle/types';
+import useRestorationFromUrlState from '@/core/hooks/useRestorationFromUrlState';
 import { fetchAnalytics } from '@/views/Finances/api/queries';
 import type { LineChartSeriesData } from '@/views/Finances/utils/types';
 import { buildExpenseMetricsLineChartSeries } from '@/views/Finances/utils/utils';
+import { FinancesSectionId } from '../../types';
 import type { AnalyticGranularity, AnalyticMetric, AnalyticSeriesRow } from '@ses/core/models/interfaces/analytic';
 
 export type CumulativeType = 'relative' | 'absolute';
+const DEFAULT_GRANULARITY = 'monthly';
+const DEFAULT_CUMULATIVE = false;
+const DEFAULT_CUMULATIVE_TYPE = 'relative';
 
 export const useExpenseMetrics = (year: string) => {
   const theme = useTheme();
 
-  const [selectedGranularity, setSelectedGranularity] = useState<AnalyticGranularity>('monthly');
-  const [isCumulative, setIsCumulative] = useState(false);
-  const [cumulativeType, setCumulativeType] = useState<CumulativeType>('relative');
+  const [selectedGranularity, setSelectedGranularity] = useState<AnalyticGranularity>(DEFAULT_GRANULARITY);
+  const [isCumulative, setIsCumulative] = useState(DEFAULT_CUMULATIVE);
+  const [cumulativeType, setCumulativeType] = useState<CumulativeType>(DEFAULT_CUMULATIVE_TYPE);
 
   const router = useRouter();
   const urlPath = Array.isArray(router.query.path) ? router.query.path.join('/') : router.query.path;
   const codePath = urlPath ? `atlas/${urlPath}` : 'atlas';
   const levelOfDetail = codePath === 'atlas' ? 1 : codePath.split('/').length;
+
+  const { handleCurrentSectionStateUpdate } = useRestorationFromUrlState(FinancesSectionId.EXPENSE_METRICS, (state) => {
+    if (state?.granularity && state.granularity.length > 0) {
+      setSelectedGranularity(state.granularity[0] as AnalyticGranularity);
+    }
+    if (state?.cumulative && state.cumulative.length > 0) {
+      setIsCumulative(Boolean(state.cumulative[0]));
+    }
+    if (state?.cumulativeType && state.cumulativeType.length > 0) {
+      setCumulativeType(state.cumulativeType[0] as CumulativeType);
+    }
+  });
 
   // fetch actual data from the API
   const { data: analytics, error } = useSWRImmutable([selectedGranularity, year, codePath, levelOfDetail], async () =>
@@ -30,10 +47,15 @@ export const useExpenseMetrics = (year: string) => {
 
   const handleChangeCumulativeType = (value: CumulativeType) => {
     setCumulativeType(value);
+    handleCurrentSectionStateUpdate({ cumulativeType: value });
   };
   const handleToggleCumulative = () => {
-    setIsCumulative((prev) => !prev);
-    setCumulativeType('relative');
+    setIsCumulative(!isCumulative);
+    setCumulativeType(DEFAULT_CUMULATIVE_TYPE);
+    handleCurrentSectionStateUpdate({
+      cumulative: (!isCumulative).toString(),
+      cumulativeType: DEFAULT_CUMULATIVE_TYPE,
+    });
   };
 
   const isLoading = !analytics && !error;
@@ -174,6 +196,7 @@ export const useExpenseMetrics = (year: string) => {
       selected: selectedGranularity,
       onChange: (value: string | number | (string | number)[]) => {
         setSelectedGranularity(value as AnalyticGranularity);
+        handleCurrentSectionStateUpdate({ granularity: value as string });
       },
       widthStyles: {
         width: 'fit-content',
@@ -189,19 +212,20 @@ export const useExpenseMetrics = (year: string) => {
       handleToggleCumulative,
       selected: isCumulative,
       options: cumulativeItems,
-      onChange: () => {
-        setIsCumulative((prev) => !prev);
-        setCumulativeType('relative');
-      },
     },
   ];
 
   const canReset = selectedGranularity !== 'monthly' || isCumulative;
 
   const onReset = () => {
-    setSelectedGranularity('monthly');
-    setIsCumulative(false);
-    setCumulativeType('relative');
+    setSelectedGranularity(DEFAULT_GRANULARITY);
+    setIsCumulative(DEFAULT_CUMULATIVE);
+    setCumulativeType(DEFAULT_CUMULATIVE_TYPE);
+    handleCurrentSectionStateUpdate({
+      granularity: DEFAULT_GRANULARITY,
+      cumulative: DEFAULT_CUMULATIVE.toString(),
+      cumulativeType: DEFAULT_CUMULATIVE_TYPE,
+    });
   };
 
   return {

--- a/src/views/Finances/components/FinancesTable/FinancesTable.tsx
+++ b/src/views/Finances/components/FinancesTable/FinancesTable.tsx
@@ -2,6 +2,7 @@ import { styled, useMediaQuery } from '@mui/material';
 import { siteRoutes } from '@ses/config/routes';
 import { usLocalizedNumber } from '@ses/core/utils/humanization';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { defaultOrder, orderMetrics } from '../HeaderTable/utils';
 import LinkCellComponent from '../LinkCellComponent/LinkCellComponent';
 import { removePatternAfterSlash } from '../SectionPages/BreakdownTable/utils';
@@ -13,11 +14,11 @@ interface Props {
   className?: string;
   breakdownTable: TableFinances[];
   metrics: string[];
-  year: string;
   period: PeriodicSelectionFilter;
 }
 
-const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, period, year }) => {
+const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, period }) => {
+  const router = useRouter();
   const iteration = period === 'Quarterly' ? 5 : period === 'Monthly' ? 13 : period === 'Annually' ? 1 : 3;
   const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
   const desk1440 = useMediaQuery((theme: Theme) => theme.breakpoints.up('desktop_1024'));
@@ -41,9 +42,16 @@ const FinancesTable: React.FC<Props> = ({ className, breakdownTable, metrics, pe
         <TableContainer className={className} key={index}>
           <TableBody isAnnual={isAnnual}>
             {table.rows.map((row: ItemRow, index) => {
-              const href = `${siteRoutes.finances(
-                removePatternAfterSlash(row.codePath ?? '').replace('atlas/', '')
-              )}?year=${year}&period=${period}${metrics.map((metric) => `&metric=${metric}`).join('')}#breakdown-table`;
+              const href = `${siteRoutes.finances(removePatternAfterSlash(row.codePath ?? '').replace('atlas/', ''))}${
+                router.query
+                  ? `?${new URLSearchParams(
+                      Object.fromEntries(Object.entries(router.query).filter(([key]) => key !== 'path')) as Record<
+                        string,
+                        string
+                      >
+                    ).toString()}`
+                  : ''
+              }`;
 
               return (
                 <TableRow key={index} isMain={row.isMain} isAnnual={isAnnual}>

--- a/src/views/Finances/components/SectionPages/BreakdownTable/BreakdownTable.tsx
+++ b/src/views/Finances/components/SectionPages/BreakdownTable/BreakdownTable.tsx
@@ -51,7 +51,6 @@ const BreakdownTable: React.FC<Props> = ({
           <FinancesTable
             breakdownTable={breakdownTable}
             metrics={activeItems}
-            year={year}
             period={selectedValue as PeriodicSelectionFilter}
           />
         </TableWrapper>

--- a/src/views/Finances/types.ts
+++ b/src/views/Finances/types.ts
@@ -1,0 +1,7 @@
+export enum FinancesSectionId {
+  BREAKDOWN_CHART = 'bc',
+  EXPENSE_METRICS = 'em',
+  RESERVE_CHART = 'rc',
+  BREAKDOWN_TABLE = 'bt',
+  BUDGET_STATEMENTS = 'bs',
+}


### PR DESCRIPTION
## Ticket
https://trello.com/c/rRucpp5k/611-fix-the-deeplink-applied-in-breakdown-chart

## Description
Allow to conserve the filter state when the URL is shared

## What solved

- [X] Should the Line Chart anchor link work properly
- [X] Should the Reserves Chart anchor link work properly
- [X] Should the Budget Statements anchor link work properly.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
