### PR TITLE
Fix breakdown chart filtering

### DIFF
--- a/src/views/Finances/components/BreakdownChartSection/useBreakdownChart.ts
+++ b/src/views/Finances/components/BreakdownChartSection/useBreakdownChart.ts
@@ -95,7 +95,7 @@ const useBreakdownChart = (budgets: Budget[], year: string, codePath: string, al
       budgets,
       isLight,
       barWidth,
-      getKeyMetricBreakDownChart(selectedMetric),
+      selectedMetric,
       allBudgets
     );
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/NiBjQ4cs/615-breakdown-chart-filter-wrong-behavior

## Description
Some filters were showing the budget data, this was fixed

## What solved

- [X] Should the chart show the values depending on the selected metric.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
