### PR TITLE
[Fix-626] Add the height to the filter

### DIFF
--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -31,7 +31,10 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
     withAll,
     onChange,
   });
-  const combinedMenuProps = deepmerge(StyledMenuProps(theme, style?.menuWidth || 200), menuProps);
+  const combinedMenuProps = deepmerge(
+    StyledMenuProps(theme, style?.menuWidth || 200, style?.height || 'fit-content'),
+    menuProps
+  );
 
   return (
     <StyledFormControl
@@ -199,9 +202,10 @@ const CheckIcon = styled(Check)(() => ({
   height: 16,
 }));
 
-const StyledMenuProps = (theme: Theme, width: number) => ({
+const StyledMenuProps = (theme: Theme, width: number, height: string | number) => ({
   PaperProps: {
     sx: {
+      height,
       width: `${width}px`,
       color: '#000',
       backgroundImage: 'none',

--- a/src/components/CustomSelect/type.ts
+++ b/src/components/CustomSelect/type.ts
@@ -24,6 +24,7 @@ export interface CustomSelectProps {
     width?: CSSProperties['width']; // value in px
     menuWidth?: number; // value in px
     maxWidth?: number; // value in px
+    height?: CSSProperties['height']; // value in px
   };
   notShowDescription?: boolean;
   className?: string;

--- a/src/components/FiltersBundle/types.ts
+++ b/src/components/FiltersBundle/types.ts
@@ -49,6 +49,7 @@ export interface SelectFilter extends GenericFilter {
     width?: CSSProperties['width'];
     menuWidth?: number; // value in px
     maxWidth?: number; // value in px
+    height?: CSSProperties['height']; // value in px
   };
   // Height of the items default should be 32px for container of options
   itemOptionStyles?: {

--- a/src/views/Finances/components/SectionPages/ReservesWaterfallChartSection/useReservesWaterfallChart.tsx
+++ b/src/views/Finances/components/SectionPages/ReservesWaterfallChartSection/useReservesWaterfallChart.tsx
@@ -230,6 +230,7 @@ export const useReservesWaterfallChart = (codePath: string, budgets: Budget[], a
       widthStyles: {
         width: 'fit-content',
         menuWidth: 350,
+        height: items.length > 6 ? 300 : undefined,
       },
     },
   ];


### PR DESCRIPTION

## Ticket
https://trello.com/c/5deezFMQ/626-fix-avatar-in-roadmaps-section

## What solved
- [X] Fix height in the select to allow scroll when there its to many items

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
