### PR TITLE
[FIX-612] Update the docs link in the Footer

### DIFF
--- a/src/components/Footer/data.tsx
+++ b/src/components/Footer/data.tsx
@@ -52,7 +52,7 @@ const linkCategory: LinkCategory[] = [
       },
       {
         label: 'Sky Technical Documentation',
-        link: 'https://docs.sky.money/',
+        link: 'https://developers.sky.money/',
       },
       {
         label: 'Brand Assets',


### PR DESCRIPTION
## Ticket
https://trello.com/c/SoK5CWMq/612-footer-linking-updates-sept-13

## Description
Update the docs link in the Footer

## What solved

- [X] Should update the Technical Documentation link from https://docs.sky.money to https://developers.sky.money

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have performed a self-review of my own chromatic changes
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have checked my code and corrected any misspellings
- [X] I have removed any unnecessary console messages
- [X] I have removed any commented code
- [X] I have checked that there are no buggy stories in Storybook