### PR TITLE
[Fix-626] Fix the scroll in the reserve chart

### DIFF
--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -246,6 +246,17 @@ const StyledMenuProps = (theme: Theme, width: number, height: string | number) =
           bgcolor: `${theme.palette.isLight ? 'rgba(243, 245, 247, 0.50)' : 'rgba(37, 42, 52, 0.20)'} !important`,
         },
       },
+      // Add this style for scroll in case fix height props are passed
+      '&::-webkit-scrollbar': {
+        width: 4,
+        marginLeft: 4,
+        borderRadius: 12,
+      },
+      '&::-webkit-scrollbar-thumb': {
+        background: theme.palette.isLight ? theme.palette.colors.charcoal[500] : theme.palette.colors.charcoal[700],
+        borderRadius: 12,
+        height: 16,
+      },
     },
   },
 

--- a/src/views/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.tsx
+++ b/src/views/Finances/components/DelegateExpenseTrend/DelegateExpenseTrendItem.tsx
@@ -205,7 +205,9 @@ const ExtendedGenericDelegate = styled(GenericDelegateCard)(({ theme }) => ({
   },
 }));
 
-const CircleAvatarWithIconStyled = styled(CircleAvatarWithIcon)<{ isCoreUnit: boolean }>(({ isCoreUnit, theme }) => ({
+const CircleAvatarWithIconStyled = styled(CircleAvatarWithIcon, {
+  shouldForwardProp: (prop) => prop !== 'isCoreUnit',
+})<{ isCoreUnit: boolean }>(({ isCoreUnit, theme }) => ({
   width: 39,
   height: 38,
   minWidth: 39,

--- a/src/views/Home/components/FinancesLineChart/FinancesLineChart.tsx
+++ b/src/views/Home/components/FinancesLineChart/FinancesLineChart.tsx
@@ -451,7 +451,9 @@ const LegendItem = styled('div')(({ theme }) => ({
   },
 }));
 
-const Dot = styled('div')<{ color: string }>(({ theme, color }) => ({
+const Dot = styled('div', {
+  shouldForwardProp: (prop) => prop !== 'color',
+})<{ color: string }>(({ theme, color }) => ({
   width: 8,
   height: 8,
   borderRadius: '50%',

--- a/src/views/Home/components/GovernanceSection/Proposals/Proposals.tsx
+++ b/src/views/Home/components/GovernanceSection/Proposals/Proposals.tsx
@@ -79,7 +79,9 @@ const ProposalsContainer = styled(Card)(() => ({
 
 const SectionContainer = styled('section')(() => ({}));
 
-const SectionHeader = styled('div')<{ isMain?: boolean }>(({ theme, isMain = false }) => ({
+const SectionHeader = styled('div', {
+  shouldForwardProp: (prop) => prop !== 'isMain',
+})<{ isMain?: boolean }>(({ theme, isMain = false }) => ({
   display: 'flex',
   flexDirection: 'column',
   gap: 8,


### PR DESCRIPTION
## Ticket
https://trello.com/c/5deezFMQ/626-fix-scroll-bar-in-the-reserves-chart-filters

## What solved
- [X] Fix the scroll when there its many items in reserve chart 

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
![Uploading image.png…]()
