### PR TITLE
Disable legacy Production  env auto deploy

### DIFF
--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -1,8 +1,6 @@
 name: Production deployment
 
 on:
-  push:
-    branches: [ sky-production ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Ticket
https://trello.com/c/sElhmuTd

## Description
The legacy production environment auto-deploy in the github actions is now disabled, it need to be deployed manually from any tag or branch

## What solved

- [X] Should disable legacy production auto-deploy

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook
