### PR TITLE
[Fix-635] Fix year changes reset query parameters in URL

### DIFF
--- a/src/views/Finances/useFinancesView.tsx
+++ b/src/views/Finances/useFinancesView.tsx
@@ -48,8 +48,13 @@ export const useFinancesView = (budgets: Budget[], allBudgets: Budget[], initial
 
   const handleChangeYears = (value: string) => {
     setYear(value);
-    router.push(
-      `${siteRoutes.finances(codePath.split('/').slice(1, levelNumber).join('/'))}?year=${value}`,
+    router.replace(
+      {
+        query: {
+          ...router.query,
+          year: value,
+        },
+      },
       undefined,
       { shallow: true }
     );


### PR DESCRIPTION
## Ticket
https://trello.com/c/ugz1Mvkk/635-filters-are-removed-from-the-url-when-the-year-is-changed

## Description
When the year is changed it heeps the saved filters in the URL queries

## What solved

- [X] Should the selected filters remain in the URL.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook
