### PR TITLE
[Fix-638] Add the same component for the filters

### DIFF
--- a/src/views/Finances/components/SectionPages/ExpenseReports/ExpenseReportsFilters.tsx
+++ b/src/views/Finances/components/SectionPages/ExpenseReports/ExpenseReportsFilters.tsx
@@ -5,6 +5,7 @@ import FiltersBundle from '@/components/FiltersBundle/FiltersBundle';
 import type { Filter, ResetFilter } from '@/components/FiltersBundle/types';
 import SortsBundle from '@/components/SortsBundle/SortsBundle';
 import type { Sort } from '@/components/SortsBundle/types';
+import ExpenseReportStatus from '@/views/CoreUnitBudgetStatement/components/ExpenseReportStatus/ExpenseReportStatus';
 import type { Theme } from '@mui/material';
 import type { AnalyticMetric } from '@ses/core/models/interfaces/analytic';
 import type { BudgetStatus } from '@ses/core/models/interfaces/types';
@@ -88,9 +89,7 @@ const ExpenseReportsFilters: FC<ExpenseReportsFiltersProps> = ({
       selected: selectedStatuses,
       multiple: true,
       onChange: (values) => onStatusSelectChange(values as BudgetStatus[]),
-      customOptionsRender: (option) => (
-        <FilterChip status={option.value as BudgetStatus} text={option.label as string} />
-      ),
+      customOptionsRender: (option) => <ExpenseReportStatus status={option.value as BudgetStatus} />,
       widthStyles: {
         width: 'fit-content',
         menuWidth: 220,


### PR DESCRIPTION
## Ticket
https://trello.com/c/lC3i4BF2/638-apply-the-proper-color-to-status-chip-in-budget-statements-filter



## What solved

- [X] Should apply the proper colors to the chips in the Status filter.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
