### PR TITLE
[FEAT-459] RESKIN BSS-1 Budget Statements: Recognized Delegates view (Forecast Tab)

### DIFF
--- a/src/components/TeamHeader/CoreUnitSubmissionLink.tsx
+++ b/src/components/TeamHeader/CoreUnitSubmissionLink.tsx
@@ -39,7 +39,7 @@ const SinceDateCoreUnit = styled(ExternalLinkButton)(({ theme }) => ({
   padding: '0px 2px 0px 4px',
   fontSize: 12,
   fontWeight: 500,
-  lineHeight: '24px',
+  lineHeight: '22.4px',
   alignItems: 'center',
   border: `1px solid ${
     theme.palette.isLight ? theme.palette.colors.charcoal[100] : theme.palette.colors.charcoal[800]

--- a/src/views/RecognizedDelegatesBudgetStatement/components/DelegatesActuals/DelegatesActuals.tsx
+++ b/src/views/RecognizedDelegatesBudgetStatement/components/DelegatesActuals/DelegatesActuals.tsx
@@ -1,8 +1,8 @@
 import { styled } from '@mui/material';
 import { AdvancedInnerTable } from '@/components/AdvancedInnerTable/AdvancedInnerTable';
+import BudgetStatementsPlaceholder from '@/components/PlaceHolders/BudgetStatementsPlaceholder';
 import type { BudgetStatement } from '@/core/models/interfaces/budgetStatement';
 import { ResourceType } from '@/core/models/interfaces/types';
-import { TransparencyEmptyTable } from '@/views/CoreUnitBudgetStatement/components/Placeholders/TransparencyEmptyTable';
 import TransactionLink from '../TransactionLink/TransactionLink';
 import { useDelegatesActuals } from './useDelegatesActuals';
 import type { DateTime } from 'luxon';
@@ -34,10 +34,11 @@ const DelegatesActuals: FC<Props> = ({ currentMonth, budgetStatement }) => {
       <AdvancedInnerTable
         columns={mainTableColumnsActuals}
         items={mainTableItemsActuals}
+        cardSpacingSize="small"
         cardsTotalPosition="top"
         longCode="DEL"
         tablePlaceholder={
-          <TransparencyEmptyTable breakdown longCode="DEL" shortCode="DEL" resource={ResourceType.Delegates} />
+          <BudgetStatementsPlaceholder longCode="DEL" shortCode="DEL" resource={ResourceType.Delegates} />
         }
       />
       {mainTableItemsActuals.length > 0 && (
@@ -47,9 +48,10 @@ const DelegatesActuals: FC<Props> = ({ currentMonth, budgetStatement }) => {
         <AdvancedInnerTable
           columns={breakdownColumnsActuals}
           items={breakdownItemsActuals}
+          cardSpacingSize="small"
           longCode="DEL"
           tablePlaceholder={
-            <TransparencyEmptyTable breakdown longCode="DEL" shortCode="DEL" resource={ResourceType.Delegates} />
+            <BudgetStatementsPlaceholder longCode="DEL" shortCode="DEL" resource={ResourceType.Delegates} />
           }
         />
       )}

--- a/src/views/RecognizedDelegatesBudgetStatement/components/DelegatesActuals/useDelegatesActuals.ts
+++ b/src/views/RecognizedDelegatesBudgetStatement/components/DelegatesActuals/useDelegatesActuals.ts
@@ -112,7 +112,7 @@ export const useDelegatesActuals = (propsCurrentMonth: DateTime, budgetStatement
   const mainTableColumnsActuals = useMemo(() => {
     const mainTableColumnsActuals: InnerTableColumn[] = [
       {
-        header: 'Budget',
+        header: 'Wallet',
         align: 'left',
         type: 'custom',
         cellRender: renderWallet,
@@ -124,16 +124,19 @@ export const useDelegatesActuals = (propsCurrentMonth: DateTime, budgetStatement
         header: 'Forecast',
         align: 'right',
         type: 'incomeNumber',
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'Actuals',
         align: 'right',
         type: 'incomeNumber',
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'Difference',
         align: 'right',
         type: 'number',
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'Payments',
@@ -221,7 +224,7 @@ export const useDelegatesActuals = (propsCurrentMonth: DateTime, budgetStatement
   const breakdownColumnsActuals = useMemo(() => {
     const breakdownColumns: InnerTableColumn[] = [
       {
-        header: 'Recognized delegates',
+        header: 'Recognized Delegates',
         align: 'left',
         type: 'text',
         hidden: !hasGroups,
@@ -235,27 +238,32 @@ export const useDelegatesActuals = (propsCurrentMonth: DateTime, budgetStatement
         isCardHeader: true,
         width: hasGroups ? '220px' : '240px',
         hidden: true,
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'Forecast',
         align: 'right',
         type: 'incomeNumber',
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'Actuals',
         align: 'right',
         type: 'incomeNumber',
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'Difference',
         align: 'right',
         type: 'number',
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'Comments',
         align: 'left',
         type: 'text',
         width: '300px',
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'Payments',
@@ -294,6 +302,7 @@ export const useDelegatesActuals = (propsCurrentMonth: DateTime, budgetStatement
 
           result.push({
             type: type || 'normal',
+            borderBottom: true,
             items: [
               {
                 column: breakdownColumnsActuals[0],

--- a/src/views/RecognizedDelegatesBudgetStatement/components/DelegatesForecast/DelegatesForecast.tsx
+++ b/src/views/RecognizedDelegatesBudgetStatement/components/DelegatesForecast/DelegatesForecast.tsx
@@ -1,8 +1,8 @@
 import { styled } from '@mui/material';
 import { AdvancedInnerTable } from '@/components/AdvancedInnerTable/AdvancedInnerTable';
+import BudgetStatementsPlaceholder from '@/components/PlaceHolders/BudgetStatementsPlaceholder';
 import type { BudgetStatement } from '@/core/models/interfaces/budgetStatement';
 import { ResourceType } from '@/core/models/interfaces/types';
-import { TransparencyEmptyTable } from '@/views/CoreUnitBudgetStatement/components/Placeholders/TransparencyEmptyTable';
 import { useDelegatesForecast } from './useDelegatesForecast';
 import type { DateTime } from 'luxon';
 import type { FC } from 'react';
@@ -22,11 +22,11 @@ const DelegatesForecast: FC<Props> = ({ currentMonth, budgetStatement }) => {
       <AdvancedInnerTable
         columns={mainTableColumnsForecast}
         items={mainTableItemsForecast}
-        style={{ marginBottom: '64px' }}
+        cardSpacingSize="small"
         cardsTotalPosition="top"
         longCode="DEL"
         tablePlaceholder={
-          <TransparencyEmptyTable breakdown longCode="DEL" shortCode="DEL" resource={ResourceType.Delegates} />
+          <BudgetStatementsPlaceholder longCode="DEL" shortCode="DEL" resource={ResourceType.Delegates} />
         }
       />
       {mainTableItemsForecast.length > 0 && (
@@ -38,9 +38,9 @@ const DelegatesForecast: FC<Props> = ({ currentMonth, budgetStatement }) => {
           columns={breakdownHeadersForecast}
           items={breakdownItemsForecast}
           longCode="DEL"
-          style={{ marginBottom: '64px' }}
+          cardSpacingSize="small"
           tablePlaceholder={
-            <TransparencyEmptyTable breakdown longCode="DEL" shortCode="DEL" resource={ResourceType.Delegates} />
+            <BudgetStatementsPlaceholder longCode="DEL" shortCode="DEL" resource={ResourceType.Delegates} />
           }
         />
       )}
@@ -55,35 +55,31 @@ const Container = styled('div')(() => ({
 
 const TotalsMonth = styled('div')(({ theme }) => ({
   fontFamily: 'Inter, sans-serif',
-  fontStyle: 'normal',
   fontWeight: 700,
-  fontSize: '16px',
-  lineHeight: '19px',
-  color: theme.palette.isLight ? '#231536' : '#9FAFB9',
+  fontSize: 16,
+  lineHeight: '24px',
+  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
+  marginTop: 24,
   marginBottom: 16,
 
   [theme.breakpoints.up('tablet_768')]: {
-    marginBottom: 24,
-    fontSize: '20px',
-    lineHeight: '24px',
+    fontSize: 18,
+    lineHeight: '21.6px',
   },
 }));
 
 const TitleBreakdown = styled('div')(({ theme }) => ({
   fontFamily: 'Inter, sans-serif',
-  fontStyle: 'normal',
-  fontWeight: 600,
-  fontSize: '16px',
+  fontWeight: 700,
+  fontSize: 16,
   lineHeight: '19px',
-  letterSpacing: '0.4px',
-  marginTop: 40,
-  marginBottom: 32,
-  color: theme.palette.isLight ? '#231536' : '#9FAFB9',
+  color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
+  marginTop: 32,
+  marginBottom: 16,
 
   [theme.breakpoints.up('tablet_768')]: {
-    marginTop: 0,
-    fontSize: '20px',
-    lineHeight: '24px',
+    fontSize: 18,
+    lineHeight: '21.6px',
   },
 }));
 

--- a/src/views/RecognizedDelegatesBudgetStatement/components/DelegatesForecast/useDelegatesForecast.ts
+++ b/src/views/RecognizedDelegatesBudgetStatement/components/DelegatesForecast/useDelegatesForecast.ts
@@ -259,7 +259,7 @@ export const useDelegatesForecast = (currentMonth: DateTime, propBudgetStatement
   const mainTableColumnsForecast: InnerTableColumn[] = useMemo(
     () => [
       {
-        header: 'BUDGET',
+        header: 'Wallet',
         type: 'custom',
         cellRender: renderWallet,
         isCardHeader: true,
@@ -270,26 +270,31 @@ export const useDelegatesForecast = (currentMonth: DateTime, propBudgetStatement
         header: firstMonthForecast.toFormat('MMMM'),
         type: 'number',
         align: 'right',
+        hasBorderBottomOnCard: true,
       },
       {
         header: secondMonthForecast.toFormat('MMMM'),
         type: 'number',
         align: 'right',
+        hasBorderBottomOnCard: true,
       },
       {
         header: thirdMonthForecast.toFormat('MMMM'),
         type: 'number',
         align: 'right',
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'Mthly Budget',
         type: 'number',
         align: 'right',
+        hasBorderBottomOnCard: true,
       },
       {
         header: '3 Months',
         type: 'number',
         align: 'right',
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'Qtly Budget',
@@ -453,7 +458,7 @@ export const useDelegatesForecast = (currentMonth: DateTime, propBudgetStatement
   const breakdownHeadersForecast = useMemo(() => {
     const result: InnerTableColumn[] = [
       {
-        header: 'recognized delegates',
+        header: 'Recognized Delegates',
         hidden: !hasGroups,
         isCardHeader: true,
         width: '240px',
@@ -465,31 +470,37 @@ export const useDelegatesForecast = (currentMonth: DateTime, propBudgetStatement
         width: hasGroups ? '220px' : '240px',
         type: 'text',
         hidden: true,
+        hasBorderBottomOnCard: true,
       },
       {
         header: firstMonthForecast.toFormat('MMMM'),
         type: 'number',
         align: 'right',
+        hasBorderBottomOnCard: true,
       },
       {
         header: secondMonthForecast.toFormat('MMMM'),
         type: 'number',
         align: 'right',
+        hasBorderBottomOnCard: true,
       },
       {
         header: thirdMonthForecast.toFormat('MMMM'),
         type: 'number',
         align: 'right',
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'Mthly Budget',
         type: 'number',
         align: 'right',
+        hasBorderBottomOnCard: true,
       },
       {
         header: '3 Months',
         type: 'number',
         align: 'right',
+        hasBorderBottomOnCard: true,
       },
       {
         header: 'Qtly Budget',
@@ -566,6 +577,7 @@ export const useDelegatesForecast = (currentMonth: DateTime, propBudgetStatement
 
           result.push({
             type: 'normal',
+            borderBottom: true,
             items: [
               {
                 column: breakdownHeadersForecast[0],
@@ -616,6 +628,7 @@ export const useDelegatesForecast = (currentMonth: DateTime, propBudgetStatement
 
       result.push({
         type: type || 'normal',
+        borderBottom: true,
         items: [
           {
             column: breakdownHeadersForecast[0],

--- a/src/views/RecognizedDelegatesBudgetStatement/components/TransactionLink/TransactionLink.tsx
+++ b/src/views/RecognizedDelegatesBudgetStatement/components/TransactionLink/TransactionLink.tsx
@@ -8,27 +8,22 @@ interface TransactionLinkProps {
 }
 
 const TransactionLink: FC<TransactionLinkProps> = ({ href, text }) => (
-  <StyledExternalLinkButton href={href}>{text}</StyledExternalLinkButton>
+  <StyledExternalLinkButton href={href} wrapText={false}>
+    {text}
+  </StyledExternalLinkButton>
 );
 
 const StyledExternalLinkButton = styled(ExternalLinkButton)(({ theme }) => ({
+  width: 'fit-content',
   padding: '0px 6px 0px 8px',
-  alignItems: 'center',
-  border: `1px solid ${
-    theme.palette.isLight ? theme.palette.colors.charcoal[100] : theme.palette.colors.charcoal[800]
-  }`,
-  '&:hover': {
-    border: `1px solid ${
-      theme.palette.isLight ? theme.palette.colors.charcoal[200] : theme.palette.colors.charcoal[700]
-    }`,
-  },
+  lineHeight: '24.8px',
   '& div': {
     width: 16,
     height: 16,
   },
 
   [theme.breakpoints.up('tablet_768')]: {
-    padding: '3px 16px 3px 24px',
+    padding: '2px 16px 2px 24px',
     fontSize: 16,
     '& div': {
       width: 20,


### PR DESCRIPTION
## Ticket
https://trello.com/c/o6iaVCPd/459-bss-1-budget-statements-recognized-delegates-view

## Description
RESKIN BSS-1 Budget Statements: Recognized Delegates view (Forecast Tab)

## What solved

- [X] Should apply the changes for the Totals section for light/dark mode. Desktop resolutions. (fix)
- [X] Should apply the changes for the Totals section for light/dark mode. Small resolutions. (fix)
- [X] Should apply the changes for the Breakdown section for light/dark mode. Desktop resolutions. (fix)
- [X] Should apply the changes for the Breakdown section for light/dark mode. Small resolutions. (fix)
- [X] Should update the empty state for Actuals & Forecast Tabs.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have performed a self-review of my own chromatic changes
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have checked my code and corrected any misspellings
- [X] I have removed any unnecessary console messages
- [X] I have removed any commented code
- [X] I have checked that there are no buggy stories in Storybook