### PR TITLE
[Feat-610] Add styles subcard teams in contributors

### DIFF
--- a/src/views/Contributors/components/ContributorsCategoryCard.tsx
+++ b/src/views/Contributors/components/ContributorsCategoryCard.tsx
@@ -1,11 +1,7 @@
 import { styled } from '@mui/material';
-
 import React from 'react';
-import Card from '@/components/Card/Card';
-
 import InternalLinkButton from '@/components/InternalLinkButton/InternalLinkButton';
 import type { Team } from '@/core/models/interfaces/team';
-
 import TeamCard from './TeamCard';
 import type { FC } from 'react';
 
@@ -15,60 +11,54 @@ interface Props {
   title: string;
   totalContributors: number;
   href: string;
+  type: string;
 }
 
-const ContributorsCategoryCard: FC<Props> = ({ description, teams, title, totalContributors, href }) => (
+const ContributorsCategoryCard: FC<Props> = ({ description, teams, title, totalContributors, href, type }) => (
   <Container>
-    <ContainerHeaderDescription>
+    <ContainerHeaderLink>
       <Header>
         <Title>{title}</Title>
-        <LinkMobile>
-          <InternalLinkButton isLink href={href} />
-        </LinkMobile>
-        <LinkTable>
-          <InternalLinkButton isLink label="View" href={href} />
-        </LinkTable>
+        <LinkDesk>
+          <InternalLinkButton isLink label="Details" href={href} />
+        </LinkDesk>
       </Header>
-      <Description>{description}</Description>
-      <LinkDesk>
-        <InternalLinkButton isLink label="View" href={href} />
-      </LinkDesk>
-    </ContainerHeaderDescription>
-    <Content>
-      <TeamCard teams={teams} totalContributors={totalContributors} />
-    </Content>
+    </ContainerHeaderLink>
+    <ContainerCardDescriptions>
+      <ContainerDescription>
+        <Description>{description}</Description>
+      </ContainerDescription>
+      <Content>
+        <TeamCard teams={teams} totalContributors={totalContributors} type={type} />
+      </Content>
+    </ContainerCardDescriptions>
   </Container>
 );
 
 export default ContributorsCategoryCard;
 
-const Container = styled(Card)(({ theme }) => ({
-  borderRadius: 12,
-  boxShadow: 'none',
+const Container = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
   flex: 1,
-  padding: 8,
-  border: `1px solid ${theme.palette.isLight ? theme.palette.colors.gray[200] : theme.palette.colors.charcoal[800]}`,
-  background: theme.palette.isLight ? theme.palette.colors.gray[50] : theme.palette.colors.charcoal[900],
+  borderRadius: '12px 12px 12px 12px',
+  boxShadow: theme.palette.isLight ? theme.fusionShadows.graphShadow : theme.fusionShadows.darkMode,
+
   [theme.breakpoints.up('tablet_768')]: {
     flexDirection: 'column',
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    flexDirection: 'row',
-    gap: 24,
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    gap: 32,
   },
 }));
 
 const Header = styled('div')(({ theme }) => ({
   display: 'flex',
+  width: '100%',
   justifyContent: 'space-between',
   alignItems: 'center',
-  height: 32,
-  [theme.breakpoints.up('tablet_768')]: {
-    height: 'revert',
-  },
+  height: 40,
+  overflow: 'hidden',
+  padding: '4px 8px 4px 24px',
+  borderRadius: '12px 12px 0px 0px',
+  background: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
 }));
 
 const Title = styled('div')(({ theme }) => ({
@@ -85,14 +75,12 @@ const Title = styled('div')(({ theme }) => ({
 }));
 
 const Description = styled('div')(({ theme }) => ({
+  display: 'flex',
   color: theme.palette.isLight ? theme.palette.colors.gray[500] : theme.palette.colors.gray[600],
   fontFamily: 'Inter, sans-serif',
-  fontSize: 12,
-  fontWeight: 500,
-  lineHeight: '18px',
-  [theme.breakpoints.up('tablet_768')]: {
-    marginTop: 8,
-  },
+  fontSize: 14,
+  fontWeight: 600,
+  lineHeight: '22px',
   [theme.breakpoints.up('desktop_1024')]: {
     marginTop: 0,
     fontSize: 14,
@@ -103,64 +91,91 @@ const Description = styled('div')(({ theme }) => ({
 
 const Content = styled('div')(({ theme }) => ({
   display: 'flex',
-  marginTop: 16,
-  [theme.breakpoints.up('desktop_1024')]: {
-    marginTop: 0,
-    width: 452,
+  [theme.breakpoints.up('tablet_768')]: {
     flex: 1,
+    width: 271,
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    flex: 1,
+    width: 464,
   },
   [theme.breakpoints.up('desktop_1280')]: {
-    width: 465,
-  },
-  [theme.breakpoints.up('desktop_1440')]: {
     width: 512,
-    flex: 'revert',
+    flex: 1.3,
   },
 }));
 
-const ContainerHeaderDescription = styled('div')(({ theme }) => ({
+const ContainerDescription = styled('div')(({ theme }) => ({
+  borderRadius: 12,
+  padding: 8,
   display: 'flex',
-  flexDirection: 'column',
-  gap: 4,
-
+  border: `1px solid ${theme.palette.isLight ? theme.palette.colors.gray[200] : theme.palette.colors.charcoal[800]}`,
+  background: theme.palette.isLight ? theme.palette.colors.gray[50] : theme.palette.colors.charcoal[900],
   [theme.breakpoints.up('tablet_768')]: {
-    gap: 2,
+    padding: 16,
+    flex: 1.36,
+    width: 401,
   },
   [theme.breakpoints.up('desktop_1024')]: {
-    paddingLeft: 8,
-    gap: 6,
-    paddingTop: 4,
-    width: 444,
-    flex: 1,
+    padding: 16,
+    flex: 0.93,
+    width: 464,
   },
   [theme.breakpoints.up('desktop_1280')]: {
-    width: 679,
-    flex: 1.44,
+    width: 656,
+    flex: 1.6,
   },
   [theme.breakpoints.up('desktop_1440')]: {
-    width: 728,
-    flex: 1,
+    width: 768,
+    flex: 1.87,
   },
+}));
+
+const ContainerHeaderLink = styled('div')(() => ({
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
 }));
 
 const LinkDesk = styled('div')(({ theme }) => ({
-  display: 'none',
-  [theme.breakpoints.up('desktop_1024')]: {
-    display: 'flex',
-    marginTop: 2,
-    marginBottom: 6,
-  },
-}));
-const LinkMobile = styled('div')(({ theme }) => ({
   display: 'flex',
-  [theme.breakpoints.up('tablet_768')]: {
-    display: 'none',
+  '& div': {
+    color: theme.palette.isLight ? theme.palette.colors.sky[1000] : theme.palette.colors.slate[100],
+  },
+  '& path': {
+    fill: theme.palette.isLight ? theme.palette.colors.sky[1000] : theme.palette.colors.sky[1000],
+  },
+  ':hover': {
+    '& path': {
+      fill: theme.palette.isLight ? theme.palette.colors.sky[1000] : theme.palette.colors.sky[1000],
+    },
+    '& div': {
+      color: theme.palette.isLight ? theme.palette.colors.sky[1000] : theme.palette.colors.sky[1000],
+    },
   },
 }));
 
-const LinkTable = styled('div')(({ theme }) => ({
-  display: 'none',
-  [theme.breakpoints.between('tablet_768', 'desktop_1024')]: {
-    display: 'flex',
+const ContainerCardDescriptions = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  padding: 8,
+  gap: 8,
+  borderRadius: '0px 0px 12px 12px',
+
+  backgroundColor: theme.palette.isLight ? '#FFF' : theme.palette.colors.charcoal[900],
+  [theme.breakpoints.up('tablet_768')]: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 16,
+    flex: 1,
+  },
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+
+    flex: 1,
+    gap: 16,
   },
 }));

--- a/src/views/Contributors/components/Sections/ContributorsCategorySection.tsx
+++ b/src/views/Contributors/components/Sections/ContributorsCategorySection.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@mui/material';
 import React from 'react';
-import Card from '@/components/Card/Card';
+// import Card from '@/components/Card/Card';
 import type { FancyTabItem } from '@/components/FancyTabs/FancyTabs';
 import FancyTabs from '@/components/FancyTabs/FancyTabs';
 import ShadowWrapper from '@/components/FancyTabs/ShadowWrapper';
@@ -45,6 +45,7 @@ const ContributorsCategorySection: FC<Props> = ({ teams, tabs, activeTab, onTabC
                   title={currentTeams[0].name}
                   totalContributors={currentTeams[0].teams}
                   href={currentTeams[0].href}
+                  type={currentTeams[0].type === 'team' ? 'Teams' : 'Contributors'}
                 />
                 <ContributorsCategoryCard
                   description={currentTeams[1].description}
@@ -52,6 +53,7 @@ const ContributorsCategorySection: FC<Props> = ({ teams, tabs, activeTab, onTabC
                   title={currentTeams[1].name}
                   totalContributors={currentTeams[1].teams}
                   href={currentTeams[1].href}
+                  type={currentTeams[1].type === 'team' ? 'Teams' : 'Contributors'}
                 />
                 <ContributorsCategoryCard
                   description={currentTeams[2].description}
@@ -59,6 +61,7 @@ const ContributorsCategorySection: FC<Props> = ({ teams, tabs, activeTab, onTabC
                   title={currentTeams[2].name}
                   totalContributors={currentTeams[2].teams}
                   href={currentTeams[2].href}
+                  type={currentTeams[2].type === 'team' ? 'Teams' : 'Contributors'}
                 />
               </ContainerContributors>
             )}
@@ -70,6 +73,7 @@ const ContributorsCategorySection: FC<Props> = ({ teams, tabs, activeTab, onTabC
                   title={legacyTeams[0].name}
                   totalContributors={legacyTeams[0].teams}
                   href={legacyTeams[0].href}
+                  type={legacyTeams[0].type === 'team' ? 'Teams' : 'Contributors'}
                 />
                 <ContributorsCategoryCard
                   description={legacyTeams[1].description}
@@ -77,6 +81,7 @@ const ContributorsCategorySection: FC<Props> = ({ teams, tabs, activeTab, onTabC
                   title={legacyTeams[1].name}
                   totalContributors={legacyTeams[1].teams}
                   href={legacyTeams[1].href}
+                  type={legacyTeams[2].type === 'team' ? 'Teams' : 'Contributors'}
                 />
                 <ContributorsCategoryCard
                   description={legacyTeams[2].description}
@@ -84,6 +89,7 @@ const ContributorsCategorySection: FC<Props> = ({ teams, tabs, activeTab, onTabC
                   title={legacyTeams[2].name}
                   totalContributors={legacyTeams[2].teams}
                   href={legacyTeams[2].href}
+                  type={legacyTeams[2].type === 'team' ? 'Teams' : 'Contributors'}
                 />
               </ContainerContributors>
             )}
@@ -111,12 +117,14 @@ const ContainerTabs = styled('div')(({ theme }) => ({
   },
 }));
 
-const ContributorInformation = styled(Card)(() => ({
+const ContributorInformation = styled('div')(({ theme }) => ({
   width: '100%',
   display: 'flex',
   flexDirection: 'column',
-  borderRadius: '0px 12px 12px 12px',
-  overFlow: 'hidden',
+
+  [theme.breakpoints.up('desktop_1024')]: {
+    gap: 16,
+  },
 }));
 
 const Title = styled('div')(({ theme }) => ({

--- a/src/views/Contributors/components/TeamCard.tsx
+++ b/src/views/Contributors/components/TeamCard.tsx
@@ -11,7 +11,7 @@ interface Props {
   type: string;
 }
 
-const TeamCard: FC<Props> = ({ type, teams, totalContributors }) => (
+const TeamCard: FC<Props> = ({ teams, totalContributors, type }) => (
   <Card>
     <Title>
       {type} {totalContributors}

--- a/src/views/Contributors/components/TeamCard.tsx
+++ b/src/views/Contributors/components/TeamCard.tsx
@@ -8,11 +8,14 @@ import type { FC } from 'react';
 interface Props {
   teams: Team[];
   totalContributors: number;
+  type: string;
 }
 
-const TeamCard: FC<Props> = ({ teams, totalContributors }) => (
+const TeamCard: FC<Props> = ({ type, teams, totalContributors }) => (
   <Card>
-    <Title>Teams {totalContributors}</Title>
+    <Title>
+      {type} {totalContributors}
+    </Title>
 
     <TeamList>
       {teams.map((team) => (
@@ -46,7 +49,8 @@ const Card = styled('div')(({ theme }) => ({
   flexDirection: 'column',
   backgroundColor: theme.palette.isLight ? theme.palette.colors.gray[50] : '#2b303b',
   borderRadius: 6,
-
+  border: `1px solid ${theme.palette.isLight ? theme.palette.colors.gray[200] : theme.palette.colors.charcoal[800]}`,
+  overflow: 'hidden',
   gap: 8,
   [theme.breakpoints.up('tablet_768')]: {
     padding: 0,
@@ -56,17 +60,17 @@ const Card = styled('div')(({ theme }) => ({
 const Title = styled('div')(({ theme }) => ({
   background: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
   padding: '2px 0px 2px 8px',
-
-  borderRadius: '12px 12px 0px 0px',
   fontSize: 14,
   fontWeight: 600,
   lineHeight: '22px',
   color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
   [theme.breakpoints.up('tablet_768')]: {
-    padding: '2px 0px 2px 16px',
+    padding: '2px 0px 2px 8px',
   },
   [theme.breakpoints.up('desktop_1024')]: {
-    padding: '2px 12px',
+    padding: '2px 8px',
+    fontSize: 16,
+    lineHeight: '24px',
   },
 }));
 
@@ -77,16 +81,15 @@ const TeamList = styled('div')(({ theme }) => ({
   gridColumnGap: 8,
   gridRowGap: 8,
   padding: '0px 8px 8px 8px',
-  [theme.breakpoints.up('tablet_768')]: {
+
+  [theme.breakpoints.up('desktop_1024')]: {
     gridTemplateColumns: 'repeat(2, 1fr)',
-    gridTemplateRows: 'repeat(3, 1fr)',
+    gridTemplateRows: 'repeat(2, 1fr)',
     gridColumnGap: 8,
     gridRowGap: 8,
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
     padding: '0px 8px 8px 6px',
   },
   [theme.breakpoints.up('desktop_1280')]: {
-    padding: '0px 8px 0px 6px',
+    padding: '0px 8px 8px 6px',
   },
 }));

--- a/src/views/Home/components/ButtonLinkAvatar/ButtonLinkAvatar.tsx
+++ b/src/views/Home/components/ButtonLinkAvatar/ButtonLinkAvatar.tsx
@@ -89,6 +89,15 @@ const Title = styled('div')(({ theme }) => ({
   width: '100%',
 
   color: theme.palette.isLight ? theme.palette.colors.gray[900] : theme.palette.colors.gray[50],
+
+  [theme.breakpoints.up('tablet_768')]: {
+    maxWidth: 114,
+    minWidth: 'revert',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+
   [theme.breakpoints.up('desktop_1024')]: {
     maxWidth: 114,
     minWidth: 'revert',


### PR DESCRIPTION
## Ticket
https://trello.com/c/LXVDvxpS/610-cgp-12-contributors-list-section-existing-section

## What solved
- [X] Should update the card header (background, text) for light/dark mode. Desktop/Small resolutions.
- [X] Should add new styles to the card (split into 2 subsections) for light/dark mode. Desktop/Small resolutions.
- [X] Should update the description section for light/dark mode. Desktop/Small resolutions.
- [X] Should update the dark mode.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
