### PR TITLE
[FEAT-633] HOM-2.1.1 [DSR cost] Finances Homepage section

### DIFF
--- a/src/views/Home/Home.stories.tsx
+++ b/src/views/Home/Home.stories.tsx
@@ -42,6 +42,7 @@ const variantsArgs = [
         psm: 30000,
         daiSpent: 70000,
         mkrVesting: 20000,
+        dsr: 10000,
         annualProfit: 100000,
       },
       2022: {
@@ -50,6 +51,7 @@ const variantsArgs = [
         psm: 35000,
         daiSpent: 80000,
         mkrVesting: 25000,
+        dsr: 15000,
         annualProfit: 115000,
       },
       2023: {
@@ -58,6 +60,7 @@ const variantsArgs = [
         psm: 40000,
         daiSpent: 90000,
         mkrVesting: 30000,
+        dsr: 20000,
         annualProfit: 130000,
       },
       2024: {
@@ -66,6 +69,7 @@ const variantsArgs = [
         psm: 45000,
         daiSpent: 100000,
         mkrVesting: 35000,
+        dsr: 25000,
         annualProfit: 145000,
       },
     } as HomeViewProps['revenueAndSpendingData'],

--- a/src/views/Home/api/revenueAndSpending.ts
+++ b/src/views/Home/api/revenueAndSpending.ts
@@ -10,6 +10,7 @@ export interface RevenueAndSpendingData {
   psm: number;
   daiSpent: number;
   mkrVesting: number;
+  dsr: number;
   annualProfit: number;
 }
 export type RevenueAndSpendingRecords = Record<string, RevenueAndSpendingData>;
@@ -143,6 +144,7 @@ export const getRevenueAndSpendingData = async () => {
         liquidationIncome: record.liq_profit_12_mth ?? 0,
         psm: record.psm_swap_fees_12_mth ?? 0,
 
+        dsr: record.annual_interest_dsr ?? 0,
         daiSpent,
         mkrVesting,
         annualProfit: 0, // will be calculated below

--- a/src/views/Home/components/FinancesBarChart/FinancesBarChart.tsx
+++ b/src/views/Home/components/FinancesBarChart/FinancesBarChart.tsx
@@ -27,6 +27,7 @@ const FinancesBarChart: FC<FinancesBarChartProps> = ({ revenueAndSpendingData })
       psm: [],
       liquidationIncome: [],
       fees: [],
+      dsr: [],
       mkrVesting: [],
       daiSpent: [],
     };
@@ -41,6 +42,7 @@ const FinancesBarChart: FC<FinancesBarChartProps> = ({ revenueAndSpendingData })
       series.psm.push(record.psm);
       series.liquidationIncome.push(record.liquidationIncome);
       series.fees.push(record.fees);
+      series.dsr.push(record.dsr);
       series.mkrVesting.push(record.mkrVesting);
       series.daiSpent.push(record.daiSpent);
     });
@@ -102,6 +104,22 @@ const FinancesBarChart: FC<FinancesBarChartProps> = ({ revenueAndSpendingData })
       },
     },
     {
+      data: chartSeries.dsr,
+      type: 'bar',
+      stack: 'spending',
+      name: 'dsr',
+      barWidth,
+      itemStyle: {
+        color: theme.palette.isLight ? theme.palette.colors.orange[700] : theme.palette.colors.orange[900],
+        borderRadius: 0,
+      },
+      emphasis: {
+        itemStyle: {
+          color: 'inherit',
+        },
+      },
+    },
+    {
       data: chartSeries.mkrVesting,
       type: 'bar',
       stack: 'spending',
@@ -150,6 +168,33 @@ const FinancesBarChart: FC<FinancesBarChartProps> = ({ revenueAndSpendingData })
       },
       padding: 0,
       borderColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
+      position: (
+        point: [number, number],
+        params: EChartsOption,
+        dom: EChartsOption,
+        rect: EChartsOption,
+        size: EChartsOption
+      ) => {
+        const MORE_WITH = 10;
+        const withTooltip = size.contentSize[0];
+        const heightTooltip = size.contentSize[0];
+
+        let xPos = point[0];
+        let yPos = point[1];
+
+        const tooltipWidth = withTooltip;
+        const tooltipHeight = heightTooltip;
+
+        if (xPos + tooltipWidth + MORE_WITH > window.innerWidth) {
+          xPos -= tooltipWidth;
+        }
+
+        if (yPos + tooltipHeight + MORE_WITH > window.innerHeight) {
+          yPos -= tooltipHeight;
+        }
+
+        return [xPos, yPos];
+      },
       formatter: (value: BarChartSeries) => {
         const toolTipStyle = createTooltipFormatter(theme, isMobile)(value);
         return toolTipStyle;
@@ -246,6 +291,7 @@ const Container = styled('div')(({ theme }) => ({
   [theme.breakpoints.up('tablet_768')]: {
     width: 385,
     height: 253,
+    marginTop: 20,
   },
   [theme.breakpoints.up('desktop_1024')]: {
     width: 526,
@@ -253,6 +299,7 @@ const Container = styled('div')(({ theme }) => ({
   [theme.breakpoints.up('desktop_1280')]: {
     width: 449,
     height: 360,
+    marginTop: 8,
   },
   [theme.breakpoints.up('desktop_1440')]: {
     width: 480,

--- a/src/views/Home/components/FinancesBarChartCard/FinancesBarChartCard.stories.tsx
+++ b/src/views/Home/components/FinancesBarChartCard/FinancesBarChartCard.stories.tsx
@@ -25,6 +25,7 @@ const variantsArgs = [
         psm: 30000,
         daiSpent: 70000,
         mkrVesting: 20000,
+        dsr: 10000,
         annualProfit: 100000,
       },
       2022: {
@@ -33,6 +34,7 @@ const variantsArgs = [
         psm: 35000,
         daiSpent: 80000,
         mkrVesting: 25000,
+        dsr: 15000,
         annualProfit: 115000,
       },
       2023: {
@@ -41,6 +43,7 @@ const variantsArgs = [
         psm: 40000,
         daiSpent: 90000,
         mkrVesting: 30000,
+        dsr: 20000,
         annualProfit: 130000,
       },
       2024: {
@@ -49,6 +52,7 @@ const variantsArgs = [
         psm: 45000,
         daiSpent: 100000,
         mkrVesting: 35000,
+        dsr: 25000,
         annualProfit: 145000,
       },
     },

--- a/src/views/Home/components/FinancesBarChartCard/FinancesBarChartCard.tsx
+++ b/src/views/Home/components/FinancesBarChartCard/FinancesBarChartCard.tsx
@@ -1,13 +1,15 @@
-import { Button, styled } from '@mui/material';
+import { Button, styled, useMediaQuery } from '@mui/material';
 import CircleIcon from 'public/assets/svg/circle.svg';
+import Information from 'public/assets/svg/info_outlined.svg';
 import Card from '@/components/Card/Card';
 import ExternalLinkButton from '@/components/ExternalLinkButton/ExternalLinkButton';
 import InternalLinkButton from '@/components/InternalLinkButton/InternalLinkButton';
+import SESTooltip from '@/components/SESTooltip/SESTooltip';
 import { MAKERBURN_URL } from '@/config/externalUrls';
 import { siteRoutes } from '@/config/routes';
 import FinancesBarChart from '@/views/Home/components/FinancesBarChart/FinancesBarChart';
 import type { RevenueAndSpendingRecords } from '../../api/revenueAndSpending';
-import type { ButtonProps } from '@mui/material';
+import type { ButtonProps, Theme } from '@mui/material';
 import type { FC } from 'react';
 
 interface StyledButtonProps extends ButtonProps {
@@ -19,49 +21,114 @@ interface FinancesBarChartCardProps {
   years: string[];
 }
 
-const FinancesBarChartCard: FC<FinancesBarChartCardProps> = ({ revenueAndSpendingData, years }) => (
-  <Container>
-    <Title>Sky Ecosystem Finances</Title>
-    <FinancesBarChartContainer>
-      <div>
-        <FinancesBarChart revenueAndSpendingData={revenueAndSpendingData} years={years} />
-      </div>
-      <Legends>
-        <RevenueLegend>
-          <LegendTitle>Revenue</LegendTitle>
-          <RevenueLegendButtons>
-            <LegendButton index={0} startIcon={<CircleIcon />} disableRipple>
-              Fees
-            </LegendButton>
-            <LegendButton index={1} startIcon={<CircleIcon />} disableRipple>
-              Liquidation Income
-            </LegendButton>
-            <LegendButton index={2} startIcon={<CircleIcon />} disableRipple>
-              PSM
-            </LegendButton>
-          </RevenueLegendButtons>
-        </RevenueLegend>
-        <SpendingLegend>
-          <LegendTitle>Operational Spending</LegendTitle>
-          <SpendingLegendButtons>
-            <LegendButton index={3} startIcon={<CircleIcon />} disableRipple>
-              USDS/DAI Expensed
-            </LegendButton>
-            <LegendButton index={4} startIcon={<CircleIcon />} disableRipple>
-              MKR Vesting
-            </LegendButton>
-          </SpendingLegendButtons>
-        </SpendingLegend>
-      </Legends>
-    </FinancesBarChartContainer>
-    <LinkButtons>
-      <StyledExternalLinkButton href={MAKERBURN_URL} wrapText={false}>
-        makerburn.com
-      </StyledExternalLinkButton>
-      <InternalLinkButton href={siteRoutes.finances()} buttonType="primary" label="Details" />
-    </LinkButtons>
-  </Container>
-);
+const FinancesBarChartCard: FC<FinancesBarChartCardProps> = ({ revenueAndSpendingData, years }) => {
+  const isSmallDesk = useMediaQuery((theme: Theme) => theme.breakpoints.between('desktop_1024', 'desktop_1280'));
+
+  return (
+    <Container>
+      <Title>Sky Ecosystem Finances</Title>
+      <FinancesBarChartContainer>
+        <div>
+          <FinancesBarChart revenueAndSpendingData={revenueAndSpendingData} years={years} />
+        </div>
+        <Legends>
+          <RevenueLegend>
+            <LegendTitle>Revenue</LegendTitle>
+            <LegendButtonsContainer>
+              <LegendButton index={0} startIcon={<CircleIcon />} disableRipple>
+                Fees
+              </LegendButton>
+              <LegendButton index={1} startIcon={<CircleIcon />} disableRipple>
+                Liquidation Income
+              </LegendButton>
+              <LegendButton index={2} startIcon={<CircleIcon />} disableRipple>
+                PSM
+              </LegendButton>
+            </LegendButtonsContainer>
+          </RevenueLegend>
+          <SpendingLegend>
+            <LegendTitle>Spending</LegendTitle>
+            <SpendingLegendFirstSection>
+              <LegendSectionTitle>
+                <span>{isSmallDesk ? 'Opr Expenses' : 'Operational Expenses'}</span>
+                <SESTooltip
+                  content={
+                    <TooltipContent>
+                      <div>
+                        <span>USDS/DAI Expensed</span>
+                        <p>
+                          Operational costs such as salaries, services, and other day-to-day expenses necessary for the
+                          running of the Sky Ecosystem.
+                        </p>
+                      </div>
+                      <div>
+                        <span>MKR Vesting</span>
+                        <p>Governance tokens are allocated to Sky Ecosystem Contributors as a long-term incentive.</p>
+                      </div>
+                    </TooltipContent>
+                  }
+                  placement="bottom-start"
+                  enterTouchDelay={0}
+                  leaveTouchDelay={15000}
+                  showAsModal
+                >
+                  <IconWrapper>
+                    <Information />
+                  </IconWrapper>
+                </SESTooltip>
+              </LegendSectionTitle>
+              <LegendButtonsContainer>
+                <LegendButton index={3} startIcon={<CircleIcon />} disableRipple>
+                  USDS/DAI Expensed
+                </LegendButton>
+                <LegendButton index={4} startIcon={<CircleIcon />} disableRipple>
+                  MKR Vesting
+                </LegendButton>
+              </LegendButtonsContainer>
+            </SpendingLegendFirstSection>
+            <SpendingLegendSecondSection>
+              <LegendSectionTitle>
+                <span>Protocol Costs</span>
+                <SESTooltip
+                  content={
+                    <TooltipContent>
+                      <div>
+                        <span>DSR Cost</span>
+                        <p>
+                          Represents the total interest paid to DAI holders for locking their DAI in the Dai Savings
+                          Rate module.
+                        </p>
+                      </div>
+                    </TooltipContent>
+                  }
+                  placement="bottom-start"
+                  enterTouchDelay={0}
+                  leaveTouchDelay={15000}
+                  showAsModal
+                >
+                  <IconWrapper>
+                    <Information />
+                  </IconWrapper>
+                </SESTooltip>
+              </LegendSectionTitle>
+              <LegendButtonsContainer>
+                <LegendButton index={5} startIcon={<CircleIcon />} disableRipple>
+                  DSR Cost
+                </LegendButton>
+              </LegendButtonsContainer>
+            </SpendingLegendSecondSection>
+          </SpendingLegend>
+        </Legends>
+      </FinancesBarChartContainer>
+      <LinkButtons>
+        <StyledExternalLinkButton href={MAKERBURN_URL} wrapText={false}>
+          makerburn.com
+        </StyledExternalLinkButton>
+        <StyledInternalLinkButton href={siteRoutes.finances()} buttonType="primary" label="Details" />
+      </LinkButtons>
+    </Container>
+  );
+};
 
 export default FinancesBarChartCard;
 
@@ -146,22 +213,26 @@ const RevenueLegend = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  padding: '4px 8px',
-  border: `1px solid ${theme.palette.colors.gray[200]}`,
+  padding: '3.2px 8px',
+  border: `1px solid ${theme.palette.isLight ? theme.palette.colors.gray[200] : theme.palette.colors.charcoal[700]}`,
   borderRadius: 12,
 
   [theme.breakpoints.up('tablet_768')]: {
-    height: 129,
+    height: 108,
     justifyContent: 'center',
     alignItems: 'flex-start',
-    padding: '16px 16px 16px 32px',
+    padding: '13px 16px 13px 32px',
     backgroundColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
     border: 'none',
 
+    [theme.breakpoints.up('desktop_1024')]: {
+      height: 129,
+      padding: '23.5px 16px 23.5px 32px',
+    },
     [theme.breakpoints.up('desktop_1280')]: {
-      height: 120,
+      height: 144,
       flex: '1 0 0',
-      padding: '16px 24px',
+      padding: '28px 24px',
     },
   },
 }));
@@ -171,28 +242,27 @@ const SpendingLegend = styled('div')(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  padding: '4px 8px',
-  border: `1px solid ${theme.palette.colors.gray[200]}`,
-  borderRadius: 12,
+  gap: 18,
 
   [theme.breakpoints.up('tablet_768')]: {
-    height: 129,
-    justifyContent: 'center',
+    height: 150,
     alignItems: 'flex-start',
-    padding: '24px 16px 24px 32px',
+    padding: '26px 8px 8px',
     backgroundColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
-    border: 'none',
+    borderRadius: 12,
   },
-
+  [theme.breakpoints.up('desktop_1024')]: {
+    height: 129,
+    flexDirection: 'row',
+    gap: 8,
+    padding: '34px 8px 8px',
+  },
   [theme.breakpoints.up('desktop_1280')]: {
-    height: 120,
+    height: 144,
+    flexDirection: 'column',
+    gap: 18,
     flex: '1 0 0',
-    padding: '16px  15.112px 16px 24px',
-  },
-  [theme.breakpoints.up('desktop_1440')]: {
-    height: 120,
-    flex: '1 0 0',
-    padding: '16px 24px',
+    padding: '22px 9px 8px',
   },
 }));
 
@@ -223,7 +293,93 @@ const LegendTitle = styled('span')(({ theme }) => ({
   },
 }));
 
-const RevenueLegendButtons = styled('div')(({ theme }) => ({
+const SpendingLegendFirstSection = styled('div')(({ theme }) => ({
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  width: '100%',
+  padding: '11.2px 16px 7.2px',
+  border: `1px solid ${theme.palette.isLight ? theme.palette.colors.gray[200] : theme.palette.colors.charcoal[700]}`,
+  borderRadius: 12,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    height: 64,
+    alignItems: 'flex-start',
+    padding: '5.2px 8px',
+    border: `1px solid ${
+      theme.palette.isLight ? theme.palette.colors.charcoal[200] : theme.palette.colors.charcoal[700]
+    }`,
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    height: 87,
+    padding: '16.7px 8px',
+    minWidth: 'fit-content',
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    height: 64,
+    padding: '3.2px 8px',
+  },
+  [theme.breakpoints.up('desktop_1440')]: {
+    padding: '3.2px 16px',
+  },
+}));
+
+const SpendingLegendSecondSection = styled('div')(({ theme }) => ({
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  width: '100%',
+  padding: '11.2px 8px 7.2px 23px',
+  border: `1px solid ${theme.palette.isLight ? theme.palette.colors.gray[200] : theme.palette.colors.charcoal[700]}`,
+  borderRadius: 12,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    height: 34,
+    alignItems: 'flex-start',
+    padding: '5.2px 8px',
+    border: `1px solid ${
+      theme.palette.isLight ? theme.palette.colors.charcoal[200] : theme.palette.colors.charcoal[700]
+    }`,
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    height: 87,
+    padding: '3.2px 8px',
+    justifyContent: 'center',
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    height: 32,
+    padding: '3.2px 8px',
+  },
+  [theme.breakpoints.up('desktop_1440')]: {
+    padding: '3.2px 16px',
+  },
+}));
+
+const LegendSectionTitle = styled('div')(({ theme }) => ({
+  position: 'absolute',
+  left: 16,
+  top: -10,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  padding: '0px 4px',
+  backgroundColor: theme.palette.isLight ? '#FFF' : theme.palette.colors.charcoal[900],
+
+  '& > span': {
+    fontWeight: 500,
+    fontSize: 12,
+    lineHeight: '18px',
+    color: theme.palette.colors.gray[500],
+  },
+
+  [theme.breakpoints.up('tablet_768')]: {
+    backgroundColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
+  },
+}));
+
+const LegendButtonsContainer = styled('div')(({ theme }) => ({
   display: 'flex',
   gap: 24,
 
@@ -233,27 +389,12 @@ const RevenueLegendButtons = styled('div')(({ theme }) => ({
   },
 }));
 
-const SpendingLegendButtons = styled('div')(({ theme }) => ({
-  display: 'flex',
-  gap: 24,
-
-  [theme.breakpoints.up('tablet_768')]: {
-    flexDirection: 'column',
-    gap: 16,
-  },
-
-  [theme.breakpoints.up('desktop_1280')]: {
-    gap: 24,
-  },
-}));
-
 const LegendButton = styled(Button, {
   shouldForwardProp: (prop) => prop !== 'index',
 })<StyledButtonProps>(({ theme, index }) => ({
   minWidth: 'auto',
   height: 18,
   display: 'flex',
-
   alignItems: 'center',
   padding: 0,
   fontWeight: 600,
@@ -287,6 +428,9 @@ const LegendButton = styled(Button, {
       }),
       ...(index === 4 && {
         fill: theme.palette.isLight ? theme.palette.colors.red[700] : theme.palette.colors.red[900],
+      }),
+      ...(index === 5 && {
+        fill: theme.palette.isLight ? theme.palette.colors.orange[700] : theme.palette.colors.orange[900],
       }),
     },
   },
@@ -328,6 +472,63 @@ const LinkButtons = styled('div')(({ theme }) => ({
 }));
 
 const StyledExternalLinkButton = styled(ExternalLinkButton)(() => ({
-  padding: '4px 16px 4px 24px',
+  padding: '2px 16px 2px 24px',
   fontSize: 16,
+  '& > div': {
+    width: 21,
+    height: 21,
+  },
+}));
+
+const StyledInternalLinkButton = styled(InternalLinkButton)(() => ({
+  padding: '3px 16px 3px 24px',
+  '&:hover': {
+    padding: '3px 8px 3px 24px',
+  },
+}));
+
+const TooltipContent = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+
+  span: {
+    fontWeight: 700,
+    fontSize: 16,
+    lineHeight: '21.6px',
+  },
+  p: {
+    margin: 0,
+    fontWeight: 500,
+    fontSize: 16,
+    lineHeight: '24px',
+  },
+}));
+
+const IconWrapper = styled('div')(({ theme }) => ({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  cursor: 'pointer',
+  width: 12,
+  height: 12,
+  marginLeft: 7,
+  marginRight: 3,
+
+  '& svg': {
+    width: 12,
+    height: 12,
+  },
+  '& path': {
+    fill: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.slate[200],
+  },
+  '&:hover': {
+    '& path': {
+      fill: theme.palette.isLight ? theme.palette.colors.slate[200] : theme.palette.colors.slate[100],
+    },
+  },
+
+  [theme.breakpoints.up('tablet_768')]: {
+    alignItems: 'center',
+  },
 }));

--- a/src/views/Home/components/FinancesLineChart/FinancesLineChart.tsx
+++ b/src/views/Home/components/FinancesLineChart/FinancesLineChart.tsx
@@ -169,6 +169,33 @@ const FinancesLineChart: FC<FinancesLineChartProps> = ({ financesData, selectedM
       },
       padding: 0,
       borderColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
+      position: (
+        point: [number, number],
+        params: EChartsOption,
+        dom: EChartsOption,
+        rect: EChartsOption,
+        size: EChartsOption
+      ) => {
+        const MORE_WITH = 10;
+        const withTooltip = size.contentSize[0];
+        const heightTooltip = size.contentSize[0];
+
+        let xPos = point[0];
+        let yPos = point[1];
+
+        const tooltipWidth = withTooltip;
+        const tooltipHeight = heightTooltip;
+
+        if (xPos + tooltipWidth + MORE_WITH > window.innerWidth) {
+          xPos -= tooltipWidth;
+        }
+
+        if (yPos + tooltipHeight + MORE_WITH > window.innerHeight) {
+          yPos -= tooltipHeight;
+        }
+
+        return [xPos, yPos];
+      },
       formatter: function (params: BarChartSeries[]) {
         const shortAmount = params.length > 10;
         const flexDirection = shortAmount ? 'row' : 'column';
@@ -427,8 +454,9 @@ const LegendContainer = styled('div')(({ theme }) => ({
   [theme.breakpoints.up('desktop_1280')]: {
     flexDirection: 'row',
     justifyContent: 'flex-start',
-    marginTop: 16,
-    padding: '16px 24px',
+    marginTop: 12,
+    padding: '28px 24px',
+    height: 144,
   },
 }));
 

--- a/src/views/Home/components/FinancesLineChartCard/FinancesLineChartCard.tsx
+++ b/src/views/Home/components/FinancesLineChartCard/FinancesLineChartCard.tsx
@@ -271,11 +271,9 @@ const InternalButtonContainer = styled('div')(({ theme }) => ({
   marginTop: 24,
 
   '& > a': {
-    padding: '2px 14px 2px 22px',
-
+    padding: '3px 16px 3px 24px',
     '&:hover': {
-      paddingTop: 2,
-      paddingBottom: 2,
+      padding: '3px 8px 3px 24px',
     },
   },
 
@@ -283,7 +281,7 @@ const InternalButtonContainer = styled('div')(({ theme }) => ({
     marginTop: 16,
   },
   [theme.breakpoints.up('desktop_1280')]: {
-    marginTop: 22,
+    marginTop: 24,
   },
 }));
 

--- a/src/views/Home/utils/utils.tsx
+++ b/src/views/Home/utils/utils.tsx
@@ -19,7 +19,9 @@ const tooltipLabels: { [key: string]: string } = {
   psm: 'PSM',
   liquidationIncome: 'Liquidation Income',
   fees: 'Fees',
-  daiSpent: 'DAI Spent',
+  dsr: 'DSR Cost',
+  // eslint-disable-next-line spellcheck/spell-checker
+  daiSpent: 'USDS/DAI Expensed',
   mkrVesting: 'MKR Vesting',
 };
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/BRYDUzRN/633-hom-211-dsr-cost-finances-homepage-section

## Description
HOM-2.1.1 [DSR cost] Finances Homepage section

## What solved

- [X] Should Spending be split into two subsections: Operational Expenses and Protocol Costs. Light/dark mode. Desktop/Small resolutions.
- [X] Should Operational Expenses contain 2 elements: USDS/DAI Expensed and MKR Vesting.
- [X] Should Protocol Costs contain a DSR Cost element with an orange indicator.
- [X] Should update the Revenue and Spending section with the new width and height. Light/dark mode. Desktop/Small resolutions.
- [X] Should the Operation Expenses section have an info icon with the copy.
- [X] Should Protocol Costs section have an info icon with the copy: Represents the total interest paid to DAI holders for locking their DAI in the Dai Savings Rate module.
- [X] Should the DSR Cost value be represented in the bars at the bottom of the red ones.
- [X] Should get the DSR Cost value from the MakerDao API.
- [X] Should add "DSR Cost" to the tooltip & adjust its position on both charts.
- [X] Should adjust the legend area of the Breakdown Expenses chart (right side).

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have performed a self-review of my own chromatic changes
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have checked my code and corrected any misspellings
- [X] I have removed any unnecessary console messages
- [X] I have removed any commented code
- [X] I have checked that there are no buggy stories in Storybook