### PR TITLE
Fix the colors arrow in the ButtonLinkAvatar

### DIFF
--- a/src/views/Contributors/components/ContributorsCategoryCard.tsx
+++ b/src/views/Contributors/components/ContributorsCategoryCard.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@mui/material';
 import React from 'react';
-import InternalLinkButton from '@/components/InternalLinkButton/InternalLinkButton';
+import MinimalInternalLinkButton from '@/components/MinimalInternalLinkButton/MinimalInternalLinkButton';
 import type { Team } from '@/core/models/interfaces/team';
 import TeamCard from './TeamCard';
 import type { FC } from 'react';
@@ -20,7 +20,7 @@ const ContributorsCategoryCard: FC<Props> = ({ description, teams, title, totalC
       <Header>
         <Title>{title}</Title>
         <LinkDesk>
-          <InternalLinkButton isLink label="Details" href={href} />
+          <MinimalInternalLinkButton label="Details" href={href} />
         </LinkDesk>
       </Header>
     </ContainerHeaderLink>

--- a/src/views/Contributors/components/ContributorsCategoryCard.tsx
+++ b/src/views/Contributors/components/ContributorsCategoryCard.tsx
@@ -67,7 +67,7 @@ const Title = styled('div')(({ theme }) => ({
   fontSize: 14,
   fontWeight: 600,
   lineHeight: '22px',
-  [theme.breakpoints.up('tablet_768')]: {
+  [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 16,
     fontWeight: 600,
     lineHeight: '24px',
@@ -140,19 +140,9 @@ const ContainerHeaderLink = styled('div')(() => ({
 
 const LinkDesk = styled('div')(({ theme }) => ({
   display: 'flex',
-  '& div': {
-    color: theme.palette.isLight ? theme.palette.colors.sky[1000] : theme.palette.colors.slate[100],
-  },
-  '& path': {
-    fill: theme.palette.isLight ? theme.palette.colors.sky[1000] : theme.palette.colors.sky[1000],
-  },
-  ':hover': {
-    '& path': {
-      fill: theme.palette.isLight ? theme.palette.colors.sky[1000] : theme.palette.colors.sky[1000],
-    },
-    '& div': {
-      color: theme.palette.isLight ? theme.palette.colors.sky[1000] : theme.palette.colors.sky[1000],
-    },
+  marginRight: 14,
+  [theme.breakpoints.up('tablet_768')]: {
+    marginRight: 14,
   },
 }));
 

--- a/src/views/Home/components/ButtonLinkAvatar/ButtonLinkAvatar.tsx
+++ b/src/views/Home/components/ButtonLinkAvatar/ButtonLinkAvatar.tsx
@@ -38,6 +38,9 @@ const ButtonLinkWrapper = styled(Link)(({ theme }) => ({
   textDecoration: 'none',
   backgroundColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
   padding: '4px 8px 4px 8px',
+  '& path': {
+    fill: theme.palette.isLight ? theme.palette.colors.sky[1000] : theme.palette.colors.charcoal[300],
+  },
   [theme.breakpoints.up('tablet_768')]: {
     padding: '4px 8px 4px 8px',
   },


### PR DESCRIPTION
## Ticket
<!--- Your Ticket Link -->

## Description
<!--- What is new in this PR -->

## What solved

- [X] The internal link  arrow should have #9DA6B9 color 
- [X]  Background of tab descriptions. The element should be aligned with the cards below. 


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
