### PR TITLE
Fix the breakdown chart dont show legend

### DIFF
--- a/src/views/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/views/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -59,10 +59,7 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
   // Values for the grid
   const getHeightGrid = useCallback(() => {
     switch (true) {
-      case isLessMobile:
-        return 198;
-
-      case isMobile:
+      case isLessMobile || isMobile:
         return 170;
 
       case isTablet:
@@ -119,7 +116,7 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
 
   const getMarginYAxis = useCallback(() => {
     switch (true) {
-      case isMobile:
+      case isLessMobile || isMobile:
         return 5;
 
       case isTablet:
@@ -137,7 +134,7 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
       default:
         return 36;
     }
-  }, [isDesktop1024, isDesktop1280, isDesktop1440, isMobile, isTablet]);
+  }, [isDesktop1024, isDesktop1280, isDesktop1440, isLessMobile, isMobile, isTablet]);
 
   const getMarginXAxis = useCallback(() => {
     switch (true) {
@@ -515,12 +512,13 @@ const YearXAxis = styled('div', { shouldForwardProp: (prop) => prop !== 'isLessM
 
     return {
       position: 'absolute',
-      bottom: isLessMobile ? 12 : 0,
+      bottom: isLessMobile ? -6 : 0,
       left: isLessMobile ? 30 : 40,
       right: 5,
       height: 11,
       borderLeft: border,
       borderRight: border,
+
       borderBottom: border,
       borderBottomLeftRadius: 3,
       borderBottomRightRadius: 3,


### PR DESCRIPTION
## Ticket
https://trello.com/c/Mkt3vKmL/675-missing-x-y-axis-in-the-breakdown-chart

## What solved

- [X] Should make it possible to see the values in the x-y axis.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
