### PR TITLE
[Fix-610] Add the correct color to arrow

### DIFF
--- a/src/views/Home/components/ButtonLinkAvatar/ButtonLinkAvatar.tsx
+++ b/src/views/Home/components/ButtonLinkAvatar/ButtonLinkAvatar.tsx
@@ -41,6 +41,7 @@ const ButtonLinkWrapper = styled(Link)(({ theme }) => ({
   '& path': {
     fill: theme.palette.isLight ? theme.palette.colors.sky[1000] : theme.palette.colors.charcoal[300],
   },
+
   [theme.breakpoints.up('tablet_768')]: {
     padding: '4px 8px 4px 8px',
   },
@@ -72,9 +73,8 @@ const ContainerArrow = styled('div')(({ theme }) => ({
   display: 'flex',
   width: 24,
   height: 24,
-  color: theme.palette.colors.sky[1000],
   '& path': {
-    fill: theme.palette.colors.sky[1000],
+    fill: theme.palette.isLight ? theme.palette.colors.sky[1000] : theme.palette.colors.charcoal[300],
   },
 }));
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/LXVDvxpS/610-cgp-12-contributors-list-section-existing-section

## What solved
- [X] The internal link  arrow should have #9DA6B9 color [design.png]


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have performed a self-review of my own chromatic changes
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have checked my code and corrected any misspellings
- [ ] I have removed any unnecessary console messages
- [ ] I have removed any commented code
- [ ] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
