### PR TITLE
[FIX-673] Expense breakdown chart appears cut off

### DIFF
--- a/src/views/Home/components/FinancesBarChart/FinancesBarChart.tsx
+++ b/src/views/Home/components/FinancesBarChart/FinancesBarChart.tsx
@@ -155,7 +155,7 @@ const FinancesBarChart: FC<FinancesBarChartProps> = ({ revenueAndSpendingData })
 
   const options: EChartsOption = {
     tooltip: {
-      show: true,
+      show: !isMobile,
       trigger: 'axis',
       borderRadius: 12,
       backgroundColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],

--- a/src/views/Home/components/FinancesLineChart/FinancesLineChart.tsx
+++ b/src/views/Home/components/FinancesLineChart/FinancesLineChart.tsx
@@ -18,7 +18,7 @@ interface FinancesLineChartProps {
 const FinancesLineChart: FC<FinancesLineChartProps> = ({ financesData, selectedMetric, years }) => {
   const { financesLineChartRef } = useFinancesLineChart();
   const theme = useTheme();
-  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.between('mobile_375', 'tablet_768'));
+  const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('tablet_768'));
   const isTablet = useMediaQuery((theme: Theme) => theme.breakpoints.between('tablet_768', 'desktop_1024'));
   const isDesk1024 = useMediaQuery((theme: Theme) => theme.breakpoints.between('desktop_1024', 'desktop_1280'));
   const isDesk1280 = useMediaQuery((theme: Theme) => theme.breakpoints.between('desktop_1280', 'desktop_1440'));
@@ -155,7 +155,7 @@ const FinancesLineChart: FC<FinancesLineChartProps> = ({ financesData, selectedM
       width: isMobile ? 'calc(100% - 50px)' : isTablet ? 330 : isDesk1024 ? 470 : isDesk1280 ? 595 : 645,
     },
     tooltip: {
-      show: true,
+      show: !isMobile,
       trigger: 'axis',
       borderRadius: 12,
       backgroundColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],


### PR DESCRIPTION
## Ticket
https://trello.com/c/hSbvei2m/673-expense-breakdown-chart-appears-cut-off

## Description
Expense breakdown chart appears cut off

## What solved

- [X] Should the chart be displayed properly.
- [X] Should remove the tooltip for mobile.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have performed a self-review of my own chromatic changes
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have checked my code and corrected any misspellings
- [X] I have removed any unnecessary console messages
- [X] I have removed any commented code
- [X] I have checked that there are no buggy stories in Storybook