### PR TITLE
[FIX-674] Buttons Positioned Too Close Together in the Finances section

### DIFF
--- a/src/views/Home/components/FinancesBarChartCard/FinancesBarChartCard.tsx
+++ b/src/views/Home/components/FinancesBarChartCard/FinancesBarChartCard.tsx
@@ -468,12 +468,16 @@ const LinkButtons = styled('div')(({ theme }) => ({
   },
 }));
 
-const StyledExternalLinkButton = styled(ExternalLinkButton)(() => ({
+const StyledExternalLinkButton = styled(ExternalLinkButton)(({ theme }) => ({
   padding: '2px 16px 2px 24px',
   fontSize: 16,
   '& > div': {
     width: 21,
     height: 21,
+  },
+
+  [theme.breakpoints.down('mobile_375')]: {
+    padding: '2px 8px 2px 16px',
   },
 }));
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/lzXiqnzT/674-buttons-positioned-too-close-together-in-the-finances-section

## Description
Buttons Positioned Too Close Together in the Finances section

## What solved

- [X] Should show both buttons with a space between them.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have performed a self-review of my own chromatic changes
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have checked my code and corrected any misspellings
- [X] I have removed any unnecessary console messages
- [X] I have removed any commented code
- [X] I have checked that there are no buggy stories in Storybook