### PR TITLE
[Fix-675] Add the line in the quarterly metrics

### DIFF
--- a/src/views/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/views/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -55,7 +55,8 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
   const isDesktop1440 = useMediaQuery((theme: Theme) => theme.breakpoints.up('desktop_1440'));
 
   const isMobileOrLess = isMobile || isLessMobile;
-  const showLineYear = (isMobile || isLessMobile) && selectedGranularity === 'monthly';
+  const showLineYear =
+    ((isMobile || isLessMobile) && selectedGranularity === 'monthly') || selectedGranularity === 'quarterly';
   // Values for the grid
   const getHeightGrid = useCallback(() => {
     switch (true) {


### PR DESCRIPTION
## Ticket
https://trello.com/c/Mkt3vKmL/675-missing-x-y-axis-in-the-breakdown-chart


## What solved

- [X] Should the quarterly period show the year like the metrics line chart shows.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
