### PR TITLE
[FEAT-681] Create a load error page

### DIFF
--- a/pages/500.tsx
+++ b/pages/500.tsx
@@ -1,0 +1,5 @@
+import Page500View from '@/views/Page500/Page500View';
+
+const Page500 = () => <Page500View />;
+
+export default Page500;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import React, { useEffect } from 'react';
 import { CookiesProvider } from 'react-cookie';
 import { Provider } from 'react-redux';
+import ErrorBoundary from '@/components/Error/ErrorBoundary';
 import { featureFlags } from '../feature-flags/feature-flags';
 import { CURRENT_ENVIRONMENT } from '../src/config/endpoints';
 import { AuthContextProvider } from '../src/core/context/AuthContext';
@@ -95,7 +96,9 @@ function MyApp(props: MyAppProps) {
               />
               <FeatureFlagsProvider enabledFeatures={featureFlags[CURRENT_ENVIRONMENT]}>
                 <AppLayout>
-                  <Component {...pageProps} />
+                  <ErrorBoundary>
+                    <Component {...pageProps} />
+                  </ErrorBoundary>
                 </AppLayout>
                 <ContainerNotification limit={3} />
               </FeatureFlagsProvider>

--- a/src/components/Error/CustomError.tsx
+++ b/src/components/Error/CustomError.tsx
@@ -95,6 +95,8 @@ const Title = styled('div')(({ theme }) => ({
 
 const Description = styled('div')(({ theme }) => ({
   marginBottom: 56,
+  padding: '0px 24px',
+  textAlign: 'center',
   fontFamily: 'Inter, sans-serif',
   fontWeight: 700,
   fontSize: 18,

--- a/src/components/Error/CustomError.tsx
+++ b/src/components/Error/CustomError.tsx
@@ -1,0 +1,112 @@
+import { styled } from '@mui/material';
+import SkyButton from '@/components/SkyButton/SkyButton';
+import type { FC } from 'react';
+
+interface CustomErrorProps {
+  description: string;
+  skyButtonTitle: string;
+  callback: () => void;
+}
+
+const CustomError: FC<CustomErrorProps> = ({ description, skyButtonTitle, callback }) => (
+  <Container>
+    <DataContainer>
+      <Title>Oops!</Title>
+      <Description>{description}</Description>
+      <SkyButton title={skyButtonTitle} onClick={callback} />
+    </DataContainer>
+  </Container>
+);
+
+export default CustomError;
+
+const Container = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  width: '100%',
+  paddingTop: 88,
+  paddingBottom: 64,
+
+  [theme.breakpoints.up('tablet_768')]: {
+    paddingTop: 114,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    paddingBottom: 24,
+  },
+  [theme.breakpoints.up('desktop_1440')]: {
+    paddingBottom: 41,
+  },
+  [theme.breakpoints.up('desktop_1920')]: {
+    borderBottom: `1px solid ${
+      theme.palette.isLight ? theme.palette.colors.charcoal[100] : theme.palette.colors.gray[900]
+    }`,
+  },
+}));
+
+const DataContainer = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  maxWidth: 650,
+  width: 'calc(100% - 32px)',
+  height: 568,
+  backgroundImage: theme.palette.isLight ? 'url(/assets/img/empty.png)' : 'url(/assets/img/empty-dark.png)',
+  backgroundPosition: 'center',
+  backgroundRepeat: 'no-repeat',
+  backgroundSize: '100% 100%',
+
+  [theme.breakpoints.up('tablet_768')]: {
+    maxWidth: 704,
+    width: '100%',
+    height: 784,
+  },
+  [theme.breakpoints.up('desktop_1024')]: {
+    maxWidth: 960,
+    height: 712,
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    maxWidth: 1200,
+  },
+  [theme.breakpoints.up('desktop_1440')]: {
+    maxWidth: 1312,
+  },
+}));
+
+const Title = styled('div')(({ theme }) => ({
+  marginBottom: 16,
+  fontFamily: 'Inter, sans-serif',
+  fontWeight: 700,
+  fontSize: 32,
+  lineHeight: '38.4px',
+  color: theme.palette.isLight ? theme.palette.colors.gray[500] : theme.palette.colors.gray[600],
+
+  [theme.breakpoints.up('tablet_768')]: {
+    fontSize: 40,
+    lineHeight: '48px',
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    fontSize: 64,
+    lineHeight: '76.8px',
+  },
+}));
+
+const Description = styled('div')(({ theme }) => ({
+  marginBottom: 56,
+  fontFamily: 'Inter, sans-serif',
+  fontWeight: 700,
+  fontSize: 18,
+  lineHeight: '21.6px',
+  color: theme.palette.isLight ? theme.palette.colors.gray[500] : theme.palette.colors.gray[600],
+
+  [theme.breakpoints.up('tablet_768')]: {
+    fontSize: 24,
+    lineHeight: '28.8px',
+  },
+  [theme.breakpoints.up('desktop_1280')]: {
+    fontSize: 32,
+    lineHeight: '38.4px',
+  },
+}));

--- a/src/components/Error/ErrorBoundary.tsx
+++ b/src/components/Error/ErrorBoundary.tsx
@@ -1,0 +1,54 @@
+import { withRouter } from 'next/router';
+import { Component } from 'react';
+import CustomError from './CustomError';
+import type { NextRouter } from 'next/router';
+import type { ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  router: NextRouter;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  handleRouteChange() {
+    this.state.hasError && this.setState({ hasError: false });
+  }
+
+  componentDidMount() {
+    this.props.router.events.on('routeChangeComplete', () => this.handleRouteChange());
+  }
+
+  componentWillUnmount() {
+    this.props.router.events.off('routeChangeComplete', () => this.handleRouteChange);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <CustomError
+          description="Something went wrong. We'll be right back."
+          skyButtonTitle="Try again"
+          callback={() => {
+            window.location.reload();
+          }}
+        />
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default withRouter(ErrorBoundary);

--- a/src/core/utils/dictionary.js
+++ b/src/core/utils/dictionary.js
@@ -189,6 +189,7 @@ const dictionary = [
   'Chatbot',
   'Deviz',
   'Expensed',
+  'Unmount',
 ];
 
 module.exports = dictionary;

--- a/src/views/Page404/Page404View.tsx
+++ b/src/views/Page404/Page404View.tsx
@@ -1,120 +1,19 @@
-import { styled } from '@mui/material';
-import { SEOHead } from '@ses/components/SEOHead/SEOHead';
 import { useRouter } from 'next/router';
-import SkyButton from '@/components/SkyButton/SkyButton';
+import CustomError from '@/components/Error/CustomError';
 import type { FC } from 'react';
 
 const Page404View: FC = () => {
   const router = useRouter();
 
-  const handleGoHome = () => {
-    router.push('/');
-  };
-
   return (
-    <Container>
-      <SEOHead
-        title="Sky Fusion - 404"
-        description="Sky Fusion Dashboard offers key data insights into the Sky Ecosystem's finances, governance, contributors, and roadmaps."
-      />
-      <DataContainer>
-        <Title>Oops!</Title>
-        <Description>The page couldn't be found</Description>
-        <SkyButton title="Go Back to Homepage" onClick={handleGoHome} />
-      </DataContainer>
-    </Container>
+    <CustomError
+      description="The page couldn't be found"
+      skyButtonTitle="Go Back to Homepage"
+      callback={() => {
+        router.push('/');
+      }}
+    />
   );
 };
 
 export default Page404View;
-
-const Container = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
-  alignItems: 'center',
-  width: '100%',
-  paddingTop: 88,
-  paddingBottom: 64,
-
-  [theme.breakpoints.up('tablet_768')]: {
-    paddingTop: 114,
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    paddingBottom: 24,
-  },
-  [theme.breakpoints.up('desktop_1440')]: {
-    paddingBottom: 41,
-  },
-  [theme.breakpoints.up('desktop_1920')]: {
-    borderBottom: `1px solid ${
-      theme.palette.isLight ? theme.palette.colors.charcoal[100] : theme.palette.colors.gray[900]
-    }`,
-  },
-}));
-
-const DataContainer = styled('div')(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
-  alignItems: 'center',
-  maxWidth: 650,
-  width: 'calc(100% - 32px)',
-  height: 568,
-  backgroundImage: theme.palette.isLight ? 'url(/assets/img/empty.png)' : 'url(/assets/img/empty-dark.png)',
-  backgroundPosition: 'center',
-  backgroundRepeat: 'no-repeat',
-  backgroundSize: '100% 100%',
-
-  [theme.breakpoints.up('tablet_768')]: {
-    maxWidth: 704,
-    width: '100%',
-    height: 784,
-  },
-  [theme.breakpoints.up('desktop_1024')]: {
-    maxWidth: 960,
-    height: 712,
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    maxWidth: 1200,
-  },
-  [theme.breakpoints.up('desktop_1440')]: {
-    maxWidth: 1312,
-  },
-}));
-
-const Title = styled('div')(({ theme }) => ({
-  marginBottom: 16,
-  fontFamily: 'Inter, sans-serif',
-  fontWeight: 700,
-  fontSize: 32,
-  lineHeight: '38.4px',
-  color: theme.palette.isLight ? theme.palette.colors.gray[500] : theme.palette.colors.gray[600],
-
-  [theme.breakpoints.up('tablet_768')]: {
-    fontSize: 40,
-    lineHeight: '48px',
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    fontSize: 64,
-    lineHeight: '76.8px',
-  },
-}));
-
-const Description = styled('div')(({ theme }) => ({
-  marginBottom: 56,
-  fontFamily: 'Inter, sans-serif',
-  fontWeight: 700,
-  fontSize: 18,
-  lineHeight: '21.6px',
-  color: theme.palette.isLight ? theme.palette.colors.gray[500] : theme.palette.colors.gray[600],
-
-  [theme.breakpoints.up('tablet_768')]: {
-    fontSize: 24,
-    lineHeight: '28.8px',
-  },
-  [theme.breakpoints.up('desktop_1280')]: {
-    fontSize: 32,
-    lineHeight: '38.4px',
-  },
-}));

--- a/src/views/Page500/Page500View.stories.tsx
+++ b/src/views/Page500/Page500View.stories.tsx
@@ -1,0 +1,104 @@
+import { featureFlags } from 'feature-flags/feature-flags';
+import { CURRENT_ENVIRONMENT } from '@/config/endpoints';
+import { FeatureFlagsProvider } from '@/core/context/FeatureFlagsProvider';
+import { createThemeModeVariants } from '@/core/utils/storybook/factories';
+import AppLayout from '@/stories/containers/AppLayout/AppLayout';
+import Page500View from './Page500View';
+import type { Meta } from '@storybook/react';
+import type { FigmaParams } from 'sb-figma-comparator';
+
+const meta: Meta<typeof Page500View> = {
+  title: 'Fusion/Pages/Page500',
+  component: Page500View,
+  parameters: {
+    layout: 'fullscreen',
+    chromatic: {
+      viewports: [375, 768, 1024, 1280, 1440],
+      pauseAnimationAtEnd: true,
+    },
+  },
+};
+
+export default meta;
+
+const variantsArgs = [{}];
+
+const [[LightMode, DarkMode]] = createThemeModeVariants(
+  (props) => (
+    <FeatureFlagsProvider enabledFeatures={featureFlags[CURRENT_ENVIRONMENT]}>
+      <AppLayout>
+        <Page500View {...props} />
+      </AppLayout>
+    </FeatureFlagsProvider>
+  ),
+  variantsArgs,
+  false
+);
+export { LightMode, DarkMode };
+
+LightMode.parameters = {
+  figma: {
+    component: {
+      375: {
+        component: '',
+        options: {
+          componentStyle: {
+            width: 375,
+          },
+          style: {
+            top: 0,
+            left: 0,
+          },
+        },
+      },
+      768: {
+        component: '',
+        options: {
+          componentStyle: {
+            width: 768,
+          },
+          style: {
+            top: 0,
+            left: 0,
+          },
+        },
+      },
+      1024: {
+        component: '',
+        options: {
+          componentStyle: {
+            width: 1024,
+          },
+          style: {
+            top: 0,
+            left: 0,
+          },
+        },
+      },
+      1280: {
+        component: '',
+        options: {
+          componentStyle: {
+            width: 1280,
+          },
+          style: {
+            top: 0,
+            left: 0,
+          },
+        },
+      },
+      1440: {
+        component: '',
+        options: {
+          componentStyle: {
+            width: 1440,
+          },
+          style: {
+            top: 0,
+            left: 0,
+          },
+        },
+      },
+    },
+  } as FigmaParams,
+};

--- a/src/views/Page500/Page500View.tsx
+++ b/src/views/Page500/Page500View.tsx
@@ -1,0 +1,14 @@
+import CustomError from '@/components/Error/CustomError';
+import type { FC } from 'react';
+
+const Page500View: FC = () => (
+  <CustomError
+    description="Something went wrong. We'll be right back."
+    skyButtonTitle="Try again"
+    callback={() => {
+      window.location.reload();
+    }}
+  />
+);
+
+export default Page500View;


### PR DESCRIPTION
## Ticket
https://trello.com/c/YEcu2osm/681-create-a-load-error-page

## Description
Create a load error page

## What solved

- [X] Should create a new page with the 404 design.
- [X] Should use the message: Ups, something went wrong. We’ll be right back.
- [X] Should implement the dark mode & responsive view.
- [X] Should display a component when a client-side error occurs.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have performed a self-review of my own chromatic changes
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have checked my code and corrected any misspellings
- [X] I have removed any unnecessary console messages
- [X] I have removed any commented code
- [X] I have checked that there are no buggy stories in Storybook