### PR TITLE
[FIX-690] MakerDao text should be changed to Sky

### DIFF
--- a/src/views/Finances/FinancesView.tsx
+++ b/src/views/Finances/FinancesView.tsx
@@ -141,7 +141,7 @@ const FinancesView: React.FC<Props> = ({ budgets, allBudgets, yearsRange, initia
           </ContainerSpace>
           <ContainerSpace>
             <ReservesWaterfallChartSection
-              title={`${levelNumber === 1 ? (isMobile ? 'MakerDAO F.' : 'MakerDAO Finances') : title} Reserves`}
+              title={`${levelNumber === 1 ? (isMobile ? 'Sky F.' : 'Sky Finances') : title} Reserves`}
               legends={reserveChart.legendItems}
               series={reserveChart.series}
               selectedGranularity={reserveChart.selectedGranularity}
@@ -164,7 +164,7 @@ const FinancesView: React.FC<Props> = ({ budgets, allBudgets, yearsRange, initia
           breakdownTable={breakdownTable.tableBody ?? []}
           isLoading={breakdownTable.isLoading}
           headerTable={breakdownTable.tableHeader ?? []}
-          title={levelNumber === 1 ? 'MakerDAO Budget' : title}
+          title={levelNumber === 1 ? 'Sky Budget' : title}
           filters={breakdownTable.filters}
           resetFilters={breakdownTable.resetFilters}
         />


### PR DESCRIPTION
## Ticket
https://trello.com/c/M2ZP9tfv/690-makerdao-text-should-be-changed-to-sky

## Description
MakerDao text should be changed to Sky

## What solved

- [X] Should change MakerDao text to Sky in the Reserves Chart section.
- [X] Should change MakerDao text to Sky in the Breakdown Table section.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have performed a self-review of my own chromatic changes
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have checked my code and corrected any misspellings
- [X] I have removed any unnecessary console messages
- [X] I have removed any commented code
- [X] I have checked that there are no buggy stories in Storybook