### PR TITLE
[Fix-691] Add the same style for year line component

### DIFF
--- a/src/views/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/views/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -531,10 +531,10 @@ const YearXAxis = styled('div', { shouldForwardProp: (prop) => prop !== 'isLessM
 const YearText = styled('div')(({ theme }) => ({
   fontSize: 12,
   lineHeight: 'normal',
+  fontFamily: 'Open Sans Condensed, sans-serif',
   color: theme.palette.isLight ? theme.palette.colors.charcoal[200] : theme.palette.colors.charcoal[700],
   position: 'absolute',
   bottom: -6,
-
   width: 52,
   left: '50%',
   transform: 'translateX(-50%)',

--- a/src/views/Finances/components/ExpenseMetrics/ExpenseMetricsChart/ExpenseMetricsChart.tsx
+++ b/src/views/Finances/components/ExpenseMetrics/ExpenseMetricsChart/ExpenseMetricsChart.tsx
@@ -358,7 +358,7 @@ const ChartContainer = styled('div')(({ theme }) => ({
 
 const YearXAxis = styled('div')(({ theme }) => {
   const border = `1px solid ${
-    theme.palette.isLight ? theme.palette.colors.charcoal[200] : theme.palette.colors.charcoal[400]
+    theme.palette.isLight ? theme.palette.colors.charcoal[200] : theme.palette.colors.charcoal[700]
   }`;
 
   return {
@@ -377,17 +377,18 @@ const YearXAxis = styled('div')(({ theme }) => {
 
 const YearText = styled('div')(({ theme }) => ({
   position: 'absolute',
-  fontFamily: 'OpenSansCondensed, sans-serif',
+  fontFamily: 'Open Sans Condensed, sans-serif',
   fontWeight: 700,
   fontSize: 12,
   lineHeight: '16px',
-  color: theme.palette.isLight ? theme.palette.colors.charcoal[200] : theme.palette.colors.charcoal[400],
+  color: theme.palette.isLight ? theme.palette.colors.charcoal[200] : theme.palette.colors.charcoal[700],
   bottom: -6,
-  width: 36,
+  width: 52,
   left: '50%',
   transform: 'translateX(-50%)',
   backgroundColor: theme.palette.isLight ? 'white' : theme.palette.colors.charcoal[900],
   textAlign: 'center',
+  letterSpacing: '1px',
 }));
 
 const LegendContainer = styled('div')(({ theme }) => ({

--- a/src/views/Finances/components/LineYearBorderBottomChart/LineYearBorderBottomChart.tsx
+++ b/src/views/Finances/components/LineYearBorderBottomChart/LineYearBorderBottomChart.tsx
@@ -33,9 +33,10 @@ const YearXAxis = styled('div')(({ theme }) => {
 });
 
 const YearText = styled('div')(({ theme }) => ({
-  fontSize: 11,
+  fontSize: 12,
   lineHeight: 'normal',
-  color: theme.palette.isLight ? theme.palette.colors.charcoal[200] : theme.palette.colors.charcoal[800],
+  fontFamily: 'Open Sans Condensed, sans-serif',
+  color: theme.palette.isLight ? theme.palette.colors.charcoal[200] : theme.palette.colors.charcoal[700],
   position: 'absolute',
   bottom: -6,
   width: 52,
@@ -43,4 +44,5 @@ const YearText = styled('div')(({ theme }) => ({
   transform: 'translateX(-50%)',
   backgroundColor: theme.palette.isLight ? '#FFFFFF' : theme.palette.colors.charcoal[900],
   textAlign: 'center',
+  letterSpacing: '1px',
 }));

--- a/src/views/Finances/components/SectionPages/ReservesWaterfallChartSection/ReservesWaterfallChartSection.tsx
+++ b/src/views/Finances/components/SectionPages/ReservesWaterfallChartSection/ReservesWaterfallChartSection.tsx
@@ -133,7 +133,7 @@ const TooltipContent = styled('div')({
 });
 
 const FilterContainer = styled('div', {
-  shouldForwardProp: (prop) => prop !== 'shouldPositionBelow' && prop !== 'isShortTitle',
+  shouldForwardProp: (prop) => prop !== 'shouldPositionBelow' && prop !== 'height',
 })<{ shouldPositionBelow: boolean; height: number }>(({ theme, shouldPositionBelow, height }) => ({
   [theme.breakpoints.down('mobile_375')]: {
     justifyContent: 'flex-end',


### PR DESCRIPTION
## Ticket
https://trello.com/c/dSvkBxBU/691-chart-legends-show-incorrect-style

## Description
<!--- What is new in this PR -->

## What solved
- [X] Should the three sections display the same styles in the legend.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
