### PR TITLE
[FIX-697] Fix filter behavior in the Reserves Chart

### DIFF
--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -53,6 +53,18 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
         IconComponent={ExpandMore}
         className={className}
         MenuProps={combinedMenuProps as unknown as Partial<MenuProps>}
+        onOpen={() => {
+          setTimeout(() => {
+            const menuPaper = document.getElementById('custom-select-menu-paper');
+            menuPaper !== null &&
+              menuPaper.scrollTop > 0 &&
+              menuPaper.scrollTo({
+                top: 0,
+                left: 0,
+                behavior: 'instant' as ScrollBehavior,
+              });
+          }, 100);
+        }}
       >
         {notShowDescription && (
           <MenuItemLabel disabled>
@@ -204,6 +216,7 @@ const CheckIcon = styled(Check)(() => ({
 
 const StyledMenuProps = (theme: Theme, width: number, height: string | number) => ({
   PaperProps: {
+    id: 'custom-select-menu-paper',
     sx: {
       height,
       width: `${width}px`,


### PR DESCRIPTION
## Ticket
https://trello.com/c/UPrYABHE/697-fix-filter-behavior-in-the-reserves-chart

## Description
Fix filter behavior in the Reserves Chart

## What solved

- [X] Should the dropdown display the first elements instead of the latest ones.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have performed a self-review of my own chromatic changes
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have checked my code and corrected any misspellings
- [X] I have removed any unnecessary console messages
- [X] I have removed any commented code
- [X] I have checked that there are no buggy stories in Storybook