### PR TITLE
[FIX-701] Fix incorrect property in the Categories filter

### DIFF
--- a/src/components/FiltersBundle/FiltersList.tsx
+++ b/src/components/FiltersBundle/FiltersList.tsx
@@ -16,19 +16,19 @@ interface FilterListProps {
 const FilterList: React.FC<FilterListProps> = ({ filters, handleClose, heightForScroll = false }) => (
   <SimpleBarStyled heightForScroll={heightForScroll}>
     <Container>
-      {filters.map((filter) => {
+      {filters.map((filter, index) => {
         switch (filter.type) {
           case 'select': {
-            return <SelectAsList filter={filter} onClose={handleClose} />;
+            return <SelectAsList key={`SelectAsList-${index}`} filter={filter} onClose={handleClose} />;
           }
           case 'radio': {
-            return <RadioAsList filter={filter} />;
+            return <RadioAsList key={`RadioAsList-${index}`} filter={filter} />;
           }
           case 'checkbox': {
-            return <CustomCheckbox filter={filter} />;
+            return <CustomCheckbox key={`CustomCheckbox-${index}`} filter={filter} />;
           }
           case 'cumulative': {
-            return <CumulativeAsList filter={filter} />;
+            return <CumulativeAsList key={`CumulativeAsList-${index}`} filter={filter} />;
           }
           default: {
             throw new Error('Unknown filter type');
@@ -48,7 +48,9 @@ const Container = styled('div')(() => ({
   padding: '0 16px',
 }));
 
-const SimpleBarStyled = styled(SimpleBar)<{ heightForScroll?: boolean }>(({ theme, heightForScroll }) => ({
+const SimpleBarStyled = styled(SimpleBar, {
+  shouldForwardProp: (prop) => prop !== 'heightForScroll',
+})<{ heightForScroll?: boolean }>(({ theme, heightForScroll }) => ({
   overflowY: 'auto',
   maxHeight: '100%',
   '.simplebar-scrollbar::before': {

--- a/src/views/Finances/components/ReservesWaterfallFilters/CustomAllCategories.tsx
+++ b/src/views/Finances/components/ReservesWaterfallFilters/CustomAllCategories.tsx
@@ -13,6 +13,9 @@ export default CustomAllCategories;
 const Title = styled('div')<{ isActive?: boolean }>(({ theme, isActive = true }) => ({
   display: 'flex',
   flexDirection: 'row',
+  fontWeight: 600,
+  fontSize: 14,
+  lineHeight: '22px',
   color: theme.palette.isLight
     ? isActive
       ? theme.palette.colors.gray[900]


### PR DESCRIPTION
## Ticket
https://trello.com/c/ndg93LSq/701-incorrect-property-in-the-categories-filter

## Description
Fix incorrect property in the Categories filter

## What solved

- [X] Should apply the proper property.
- [X] Should fix console errors displayed when the filters are open (one in mobile & one in tablet/desktop).

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have performed a self-review of my own chromatic changes
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have checked my code and corrected any misspellings
- [X] I have removed any unnecessary console messages
- [X] I have removed any commented code
- [X] I have checked that there are no buggy stories in Storybook