### PR TITLE
Add the text to title of level in finances page in line chart section

### DIFF
--- a/src/views/Finances/FinancesView.tsx
+++ b/src/views/Finances/FinancesView.tsx
@@ -125,7 +125,7 @@ const FinancesView: React.FC<Props> = ({ budgets, allBudgets, yearsRange, initia
           <ContainerSpace>
             <ExpenseMetricsSection
               expenseMetrics={{
-                title: levelNumber === 1 ? 'Sky Expense Metrics' : title,
+                title: levelNumber === 1 ? 'Sky Expense Metrics' : `${title} Expense Metrics`,
                 selectedGranularity: expensesMetrics.selectedGranularity,
                 isCumulative: expensesMetrics.isCumulative,
                 cumulativeType: expensesMetrics.cumulativeType,

--- a/src/views/Finances/components/ExpenseMetrics/ExpenseMetricsFinances.tsx
+++ b/src/views/Finances/components/ExpenseMetrics/ExpenseMetricsFinances.tsx
@@ -38,38 +38,39 @@ const ExpenseMetricsFinances: FC<Props> = ({
   canReset,
   onReset,
 }) => {
-  const { containerRef, height, shouldPositionBelow } = useRelativePositioning(title, 24);
+  const { containerRef, height, shouldPositionBelow, titleRef, filterRef } = useRelativePositioning(title, 24);
 
   return (
     <Container>
       <Header ref={containerRef}>
-        <FinancesTitle
-          year={year}
-          title={title}
-          tooltip={
-            <TooltipContent>
-              <p>
-                Explore Sky's financial evolution in detail with this advanced line chart, which offers both cumulative
-                and flat perspectives on expenses.
-              </p>
-              <p>
-                Select the 'Absolute Cumulative' mode for a continuous tally from inception, providing a comprehensive
-                overview of long-term financial movements.
-              </p>
-              <p>
-                Use the 'Relative Cumulative' mode, which resets at the start of each chosen period, to analyze expenses
-                within specific intervals.
-              </p>
-              <p>
-                Effortlessly switch between these views to discern overarching fiscal trends or to pinpoint financial
-                developments specific to a quarter or year, aiding in strategic decision-making and performance
-                assessment.
-              </p>
-            </TooltipContent>
-          }
-        />
-
-        <FilterContainer height={height || 0} shouldPositionBelow={shouldPositionBelow}>
+        <ContainerFilter ref={titleRef}>
+          <FinancesTitle
+            year={year}
+            title={title}
+            tooltip={
+              <TooltipContent>
+                <p>
+                  Explore Sky's financial evolution in detail with this advanced line chart, which offers both
+                  cumulative and flat perspectives on expenses.
+                </p>
+                <p>
+                  Select the 'Absolute Cumulative' mode for a continuous tally from inception, providing a comprehensive
+                  overview of long-term financial movements.
+                </p>
+                <p>
+                  Use the 'Relative Cumulative' mode, which resets at the start of each chosen period, to analyze
+                  expenses within specific intervals.
+                </p>
+                <p>
+                  Effortlessly switch between these views to discern overarching fiscal trends or to pinpoint financial
+                  developments specific to a quarter or year, aiding in strategic decision-making and performance
+                  assessment.
+                </p>
+              </TooltipContent>
+            }
+          />
+        </ContainerFilter>
+        <FilterContainer ref={filterRef} shouldPositionBelow={shouldPositionBelow} height={height || 0}>
           <FiltersBundle
             asPopover={[]}
             filters={filters}
@@ -163,13 +164,14 @@ const FilterContainer = styled('div', {
       : {
           position: 'absolute',
           right: 0,
+          paddingLeft: 8,
         }),
   },
 
   [theme.breakpoints.up('tablet_768')]: {
     position: 'revert',
     marginTop: 'revert',
-
+    marginLeft: -12,
     marginBottom: 20,
   },
   [theme.breakpoints.up('desktop_1024')]: {
@@ -179,3 +181,5 @@ const FilterContainer = styled('div', {
     marginBottom: 26,
   },
 }));
+
+const ContainerFilter = styled('div')(() => ({}));


### PR DESCRIPTION
## Ticket
https://trello.com/c/uFascx9g/689-metrics-line-char-doesnt-show-the-levels-name


## What solved
-[X] The title should show the level name followed by "Expense Metrics."


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
