### PR TITLE
[Fix-694] Reduce the space when there its negative number

### DIFF
--- a/src/views/Finances/components/WaterfallChart/WaterfallChart.tsx
+++ b/src/views/Finances/components/WaterfallChart/WaterfallChart.tsx
@@ -106,7 +106,7 @@ const WaterfallChart: React.FC<Props> = ({ legends, year, selectedGranularity, s
         },
         axisLabel: {
           margin: showBiggerMarginX
-            ? 36
+            ? 30
             : isMobile
             ? 14
             : isTablet


### PR DESCRIPTION
## Ticket
https://trello.com/c/1v3nrPls/694-values-overlap-with-legend-items-in-reserve-chart


## What solved
- [X]  The space between the values (K,M) and the legend is bigger than expected.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
