### PR TITLE
Add correct space between the line and legend in waterfall

### DIFF
--- a/src/views/Finances/components/LineYearBorderBottomChart/LineYearBorderBottomChart.tsx
+++ b/src/views/Finances/components/LineYearBorderBottomChart/LineYearBorderBottomChart.tsx
@@ -20,7 +20,7 @@ const YearXAxis = styled('div')(({ theme }) => {
 
   return {
     position: 'absolute',
-    bottom: 30,
+    bottom: 40,
     left: 40,
     right: 5,
     height: 11,


### PR DESCRIPTION
## Ticket
https://trello.com/c/1v3nrPls/694-values-overlap-with-legend-items-in-reserve-chart

## What solved
- [X] Fix the space line and legend in reserve chart


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
