### PR TITLE
Add the correct color lines in breakdown chart and waterfall

### DIFF
--- a/src/views/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/views/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -368,8 +368,8 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
         },
         splitLine: {
           lineStyle: {
+            color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.slate[300],
             width: 0.25,
-            color: theme.palette.isLight ? theme.palette.colors.gray[400] : theme.palette.colors.charcoal[800],
           },
         },
       },

--- a/src/views/Finances/components/WaterfallChart/WaterfallChart.tsx
+++ b/src/views/Finances/components/WaterfallChart/WaterfallChart.tsx
@@ -174,7 +174,7 @@ const WaterfallChart: React.FC<Props> = ({ legends, year, selectedGranularity, s
         splitNumber: 9,
         splitLine: {
           lineStyle: {
-            color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.charcoal[800],
+            color: theme.palette.isLight ? theme.palette.colors.slate[100] : theme.palette.colors.slate[300],
             width: 0.25,
           },
         },
@@ -193,7 +193,6 @@ const WaterfallChart: React.FC<Props> = ({ legends, year, selectedGranularity, s
       startFinishMobile,
       startStyles,
       startYearStyles,
-      theme.palette.colors.charcoal,
       theme.palette.colors.gray,
       theme.palette.colors.slate,
       theme.palette.isLight,


### PR DESCRIPTION
What solved
[X] Add the correct color for both chart reserve and breakdonw

## Ticket
<!--- Your Ticket Link -->

## Description
<!--- What is new in this PR -->

## What solved

- [X] FR 1 item
- [X] FR 2 item...

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have performed a self-review of my own chromatic changes
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have checked my code and corrected any misspellings
- [ ] I have removed any unnecessary console messages
- [ ] I have removed any commented code
- [ ] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
