### PR TITLE
[FIX-699] Dropdown remains visible while scrolling through the view

### DIFF
--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -21,8 +21,9 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
   notShowDescription = true,
   menuProps,
   className,
+  isFixed = false,
 }) => {
-  const { theme, isAllSelected, handleChange, handleChangeAll, renderValue, isActive } = useCustomSelect({
+  const { theme, isAllSelected, selectRef, handleChange, handleChangeAll, renderValue, isActive } = useCustomSelect({
     label,
     options,
     multiple,
@@ -32,89 +33,99 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
     onChange,
   });
   const combinedMenuProps = deepmerge(
-    StyledMenuProps(theme, style?.menuWidth || 200, style?.height || 'fit-content'),
+    StyledMenuProps(theme, style?.menuWidth || 200, style?.height || 'fit-content', selectRef.current, isFixed),
     menuProps
   );
 
   return (
-    <StyledFormControl
-      variant="outlined"
-      fullWidth={style?.fullWidth || false}
-      width={style?.width || 97}
-      maxWidth={style?.maxWidth}
-      className={className}
-    >
-      <StyledSelect
-        displayEmpty
-        multiple={multiple}
-        value={selected}
-        onChange={handleChange}
-        renderValue={renderValue}
-        IconComponent={ExpandMore}
+    <Container>
+      <StyledFormControl
+        variant="outlined"
+        fullWidth={style?.fullWidth || false}
+        width={style?.width || 97}
+        maxWidth={style?.maxWidth}
         className={className}
-        MenuProps={combinedMenuProps as unknown as Partial<MenuProps>}
-        onOpen={() => {
-          setTimeout(() => {
-            const menuPaper = document.getElementById('custom-select-menu-paper');
-            menuPaper !== null &&
-              menuPaper.scrollTop > 0 &&
-              menuPaper.scrollTo({
-                top: 0,
-                left: 0,
-                behavior: 'instant' as ScrollBehavior,
-              });
-          }, 100);
-        }}
       >
-        {notShowDescription && (
-          <MenuItemLabel disabled>
-            <MenuItemLabelTypography>{typeof label === 'string' ? label : label()}</MenuItemLabelTypography>
-          </MenuItemLabel>
-        )}
+        <StyledSelect
+          ref={selectRef}
+          displayEmpty
+          multiple={multiple}
+          value={selected}
+          onChange={handleChange}
+          renderValue={renderValue}
+          IconComponent={ExpandMore}
+          className={className}
+          MenuProps={combinedMenuProps as unknown as Partial<MenuProps>}
+          onOpen={() => {
+            setTimeout(() => {
+              if (selectRef.current !== null) {
+                const menu = selectRef.current.querySelector('.MuiMenu-paper');
+                if (menu !== null) {
+                  menu.scrollTop > 0 &&
+                    menu.scrollTo({
+                      top: 0,
+                      left: 0,
+                      behavior: 'instant' as ScrollBehavior,
+                    });
+                }
+              }
+            }, 100);
+          }}
+        >
+          {notShowDescription && (
+            <MenuItemLabel disabled>
+              <MenuItemLabelTypography>{typeof label === 'string' ? label : label()}</MenuItemLabelTypography>
+            </MenuItemLabel>
+          )}
 
-        {withAll && (
-          <MenuItemDefault
-            borderTop={true}
-            borderBottom={false}
-            onClick={handleChangeAll}
-            sx={{
-              display: 'flex',
-              justifyContent: 'space-between',
-            }}
-          >
-            {(customOptionsRenderAll && customOptionsRenderAll(isAllSelected || false, theme)) || 'Select All'}
-            {multiple && <CheckIcon className={`check ${isAllSelected ? 'active' : ''}`} />}
-          </MenuItemDefault>
-        )}
-        {options.map((option, index) => (
-          <MenuItemDefault
-            borderTop={!withAll && index === 0}
-            borderBottom={index === options.length - 1}
-            key={option.value}
-            value={option.value}
-            sx={{
-              display: 'flex',
-              justifyContent: 'space-between',
-            }}
-          >
-            <Box display="flex" alignItems="center">
-              {customOptionsRender ? (
-                customOptionsRender(option, isActive(option), theme)
-              ) : (
-                <MenuItemTypography theme={theme} active={isActive(option)}>
-                  {option.label}
-                </MenuItemTypography>
-              )}
-            </Box>
-            {multiple && <CheckIcon className={`check ${isActive(option) ? 'active' : ''}`} />}
-          </MenuItemDefault>
-        ))}
-      </StyledSelect>
-    </StyledFormControl>
+          {withAll && (
+            <MenuItemDefault
+              borderTop={true}
+              borderBottom={false}
+              onClick={handleChangeAll}
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+              }}
+            >
+              {(customOptionsRenderAll && customOptionsRenderAll(isAllSelected || false, theme)) || 'Select All'}
+              {multiple && <CheckIcon className={`check ${isAllSelected ? 'active' : ''}`} />}
+            </MenuItemDefault>
+          )}
+          {options.map((option, index) => (
+            <MenuItemDefault
+              borderTop={!withAll && index === 0}
+              borderBottom={index === options.length - 1}
+              key={option.value}
+              value={option.value}
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+              }}
+            >
+              <Box display="flex" alignItems="center">
+                {customOptionsRender ? (
+                  customOptionsRender(option, isActive(option), theme)
+                ) : (
+                  <MenuItemTypography theme={theme} active={isActive(option)}>
+                    {option.label}
+                  </MenuItemTypography>
+                )}
+              </Box>
+              {multiple && <CheckIcon className={`check ${isActive(option) ? 'active' : ''}`} />}
+            </MenuItemDefault>
+          ))}
+        </StyledSelect>
+      </StyledFormControl>
+    </Container>
   );
 };
 
 export default CustomSelect;
+
+const Container = styled('div')({
+  position: 'relative',
+});
 
 const StyledFormControl = styled(FormControl, {
   shouldForwardProp: (prop) => !['maxWidth', 'fullWidth', 'width'].includes(prop as string),
@@ -176,7 +187,7 @@ const MenuItemDefault = styled(MenuItem, {
   borderTopRightRadius: borderTop ? 12 : 0,
   borderBottomLeftRadius: borderBottom ? 12 : 0,
   borderBottomRightRadius: borderBottom ? 12 : 0,
-  backgroundColor: 'transparent!important',
+  backgroundColor: 'transparent !important',
   minHeight: 32,
   margin: '4px 0',
 
@@ -214,10 +225,21 @@ const CheckIcon = styled(Check)(() => ({
   height: 16,
 }));
 
-const StyledMenuProps = (theme: Theme, width: number, height: string | number) => ({
+const StyledMenuProps = (
+  theme: Theme,
+  width: number,
+  height: string | number,
+  refDiv: HTMLDivElement | null,
+  isFixed: boolean
+) => ({
   PaperProps: {
-    id: 'custom-select-menu-paper',
     sx: {
+      ...(!isFixed && {
+        position: 'static',
+        maxWidth: '100%',
+        maxHeight: '100%',
+        minHeight: height,
+      }),
       height,
       width: `${width}px`,
       color: '#000',
@@ -226,7 +248,7 @@ const StyledMenuProps = (theme: Theme, width: number, height: string | number) =
       boxShadow: '0px 4px 6px rgba(0, 0, 0, 0.1)',
 
       '&.MuiPaper-elevation.MuiPaper-rounded': {
-        borderRadius: '12px',
+        borderRadius: '12px !important',
       },
 
       '& .MuiMenu-list': {
@@ -272,18 +294,23 @@ const StyledMenuProps = (theme: Theme, width: number, height: string | number) =
       },
     },
   },
-
+  anchorEl: refDiv,
   anchorOrigin: {
     vertical: 'bottom',
     horizontal: 'right',
   },
-
   transformOrigin: {
     vertical: 'top',
     horizontal: 'right',
   },
-
   sx: {
-    mt: 0.5,
+    ...(!isFixed && {
+      position: 'absolute',
+      top: 32,
+      left: -(width - (refDiv?.getBoundingClientRect()?.width ?? 0)),
+      width: 'fit-content',
+      height: 'fit-content',
+    }),
+    cursor: 'default',
   },
 });

--- a/src/components/CustomSelect/type.ts
+++ b/src/components/CustomSelect/type.ts
@@ -29,4 +29,5 @@ export interface CustomSelectProps {
   notShowDescription?: boolean;
   className?: string;
   menuProps?: Partial<MenuProps>;
+  isFixed?: boolean;
 }

--- a/src/components/CustomSelect/useCustomSelect.ts
+++ b/src/components/CustomSelect/useCustomSelect.ts
@@ -1,4 +1,5 @@
 import { useTheme } from '@mui/material';
+import { useRef } from 'react';
 import type { CustomSelectProps, OptionItem } from './type';
 import type { SelectChangeEvent } from '@mui/material';
 import type { ReactNode } from 'react';
@@ -25,6 +26,7 @@ export default function useCustomSelect({
   let isHandlingAll = false;
   const theme = useTheme();
   const isAllSelected = multiple && withAll && Array.isArray(selected) && selected.length === options.length;
+  const selectRef = useRef<HTMLDivElement>(null);
 
   const handleChange = (event: SelectChangeEvent<unknown>) => {
     if (!isHandlingAll) {
@@ -56,6 +58,7 @@ export default function useCustomSelect({
   return {
     theme,
     isAllSelected,
+    selectRef,
     handleChange,
     handleChangeAll,
     renderValue,

--- a/src/components/FiltersBundle/FilterDesktop.tsx
+++ b/src/components/FiltersBundle/FilterDesktop.tsx
@@ -38,7 +38,13 @@ const FilterDesktop: React.FC<FilterDesktopProps> = ({ filters, searchFilter, re
                   withAll={filter.withAll}
                   customOptionsRenderAll={filter.customOptionsRenderAll as CustomSelectProps['customOptionsRenderAll']}
                   style={filter.widthStyles}
-                  menuProps={{ disableScrollLock: true }}
+                  menuProps={{
+                    disablePortal: true,
+                    disableScrollLock: true,
+                    style: {
+                      zIndex: 7,
+                    },
+                  }}
                 />
               );
             }

--- a/src/components/FiltersBundle/FiltersList.tsx
+++ b/src/components/FiltersBundle/FiltersList.tsx
@@ -19,16 +19,16 @@ const FilterList: React.FC<FilterListProps> = ({ filters, handleClose, heightFor
       {filters.map((filter, index) => {
         switch (filter.type) {
           case 'select': {
-            return <SelectAsList key={`SelectAsList-${index}`} filter={filter} onClose={handleClose} />;
+            return <SelectAsList key={`filter-SelectAsList-${index}`} filter={filter} onClose={handleClose} />;
           }
           case 'radio': {
-            return <RadioAsList key={`RadioAsList-${index}`} filter={filter} />;
+            return <RadioAsList key={`filter-RadioAsList-${index}`} filter={filter} />;
           }
           case 'checkbox': {
-            return <CustomCheckbox key={`CustomCheckbox-${index}`} filter={filter} />;
+            return <CustomCheckbox key={`filter-CustomCheckbox-${index}`} filter={filter} />;
           }
           case 'cumulative': {
-            return <CumulativeAsList key={`CumulativeAsList-${index}`} filter={filter} />;
+            return <CumulativeAsList key={`filter-CumulativeAsList-${index}`} filter={filter} />;
           }
           default: {
             throw new Error('Unknown filter type');

--- a/src/components/FiltersBundle/defaults/CumulativeFilter/CumulativeFilter.tsx
+++ b/src/components/FiltersBundle/defaults/CumulativeFilter/CumulativeFilter.tsx
@@ -34,7 +34,7 @@ const CumulativeFilterComponent: React.FC<CumulativeFilterProps> = ({ filter }) 
   };
   return (
     <Container>
-      <SelectBtn>
+      <SelectBtn ref={anchorRef}>
         <CheckBtn onClick={filter.handleToggleCumulative}>
           {filter.isCumulative ? (
             <CheckOnComponent fill="#343839" fillDark="#D7D8D9" width={12} height={12} />
@@ -43,7 +43,7 @@ const CumulativeFilterComponent: React.FC<CumulativeFilterProps> = ({ filter }) 
           )}
         </CheckBtn>
         {getButtonText()}
-        <MenuBtn isActive={filter.isCumulative} onClick={handleOpenMenu} ref={anchorRef}>
+        <MenuBtn isActive={filter.isCumulative} onClick={handleOpenMenu}>
           <StyledSelectChevronDown
             isOpen={open}
             fill={isLight ? (filter.isCumulative ? '#25273D' : '#BEBFC5') : filter.isCumulative ? '#D7D8D9' : '#48495F'}
@@ -57,7 +57,7 @@ const CumulativeFilterComponent: React.FC<CumulativeFilterProps> = ({ filter }) 
         placement="bottom-end"
         transition
         disablePortal
-        style={{ zIndex: 1 }}
+        style={{ zIndex: 7 }}
       >
         {({ TransitionProps, placement }) => (
           <Grow

--- a/src/components/SortsBundle/SortTablet.tsx
+++ b/src/components/SortsBundle/SortTablet.tsx
@@ -16,7 +16,13 @@ const SortTablet: FC<SortTabletProps> = ({ isOpen, handleClose, sorts, anchorEl,
   const theme = useTheme();
 
   return (
-    <Popover open={isOpen} anchorEl={anchorEl.current} onClose={handleClose} {...(StyledMenuProps(theme) as object)}>
+    <Popover
+      open={isOpen}
+      anchorEl={anchorEl.current}
+      onClose={handleClose}
+      {...(StyledMenuProps(theme) as object)}
+      disableScrollLock
+    >
       <Container>
         {!!resetSorts && (
           <SortHeader>

--- a/src/components/SortsBundle/SortsList.tsx
+++ b/src/components/SortsBundle/SortsList.tsx
@@ -12,10 +12,10 @@ interface SortListProps {
 const SortsList: FC<SortListProps> = ({ sorts, handleClose }) => (
   <SimpleBarStyled>
     <Container>
-      {sorts.map((s) => {
+      {sorts.map((s, i) => {
         switch (s.type) {
           case 'column': {
-            return <CustomSelect sort={s} onClose={handleClose} />;
+            return <CustomSelect key={`sort-CustomSelect-${i}`} sort={s} onClose={handleClose} />;
           }
           default: {
             throw new Error('Unknown sort type');

--- a/src/components/TopBarNavigation/TopBarNavigation.tsx
+++ b/src/components/TopBarNavigation/TopBarNavigation.tsx
@@ -57,7 +57,11 @@ const TopBarNavigation: React.FC = () => {
                   menuWidth: 263,
                   width: 'fit-content',
                 }}
-                menuProps={{ ...StyledMenuProps(theme) }}
+                menuProps={{
+                  disableScrollLock: true,
+                  ...StyledMenuProps(theme),
+                }}
+                isFixed={true}
               />
             </SelectContainer>
           </LeftSection>
@@ -126,6 +130,7 @@ const ContainerWrapper = styled('div')<{ shouldHaveBlur: boolean }>(({ theme, sh
 
   zIndex: zIndexEnum.HEADER_PAGE,
 }));
+
 const Container = styled('nav')(({ theme }) => ({
   display: 'flex',
   backgroundColor: theme.palette.isLight ? 'rgba(243, 245, 247, 0.5)' : 'rgba(32, 39, 47, 0.5)',
@@ -158,6 +163,7 @@ const Container = styled('nav')(({ theme }) => ({
     margin: '0 auto',
   },
 }));
+
 const NavContainer = styled('div')(({ theme }) => ({
   display: 'flex',
   backgroundColor: theme.palette.isLight ? '#FFFFFF' : '#1B1E24',
@@ -194,6 +200,7 @@ const LogoContainerMobile = styled('div')(({ theme }) => ({
     display: 'none',
   },
 }));
+
 const LogoContainerDesk = styled('div')(({ theme }) => ({
   display: 'none',
   [theme.breakpoints.up('desktop_1024')]: {

--- a/src/views/Finances/components/SectionPages/BreadcrumbYearNavigation.tsx
+++ b/src/views/Finances/components/SectionPages/BreadcrumbYearNavigation.tsx
@@ -37,7 +37,13 @@ const BreadcrumbYearNavigation: React.FC<BreadcrumbYearNavigationProps> = ({
             }))}
             onChange={(value) => handleChange(value as string)}
             selected={selectedValue}
-            menuProps={{ disableScrollLock: true }}
+            menuProps={{
+              disablePortal: true,
+              disableScrollLock: true,
+              style: {
+                zIndex: 10,
+              },
+            }}
           />
         </RightContentContainer>
       }

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -176,7 +176,7 @@ a {
 }
 
 .MuiPaper-root.MuiPaper-elevation.MuiPaper-rounded {
-  border-radius: 3px 10px 10px 10px;
+  border-radius: 12px;
 }
 
 .lds-ring {


### PR DESCRIPTION
## Ticket
https://trello.com/c/QijnXnF6/699-dropdown-remains-visible-while-scrolling-through-the-view

## Description
Dropdown remains visible while scrolling through the view

## What solved

- [X] Should fix the behavior.
- [X] Should fix a console error that appears when the dropdown menu for sorting is displayed on mobile/tablet.
- [X] Should fix the border radius of the dropdown menu for filtering.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have performed a self-review of my own chromatic changes
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have checked my code and corrected any misspellings
- [X] I have removed any unnecessary console messages
- [X] I have removed any commented code
- [X] I have checked that there are no buggy stories in Storybook