### PR TITLE
[FIX-711] Filters aligned to the left side

### DIFF
--- a/src/views/Finances/components/ExpenseMetrics/ExpenseMetricsFinances.tsx
+++ b/src/views/Finances/components/ExpenseMetrics/ExpenseMetricsFinances.tsx
@@ -167,11 +167,10 @@ const FilterContainer = styled('div', {
           paddingLeft: 8,
         }),
   },
-
   [theme.breakpoints.up('tablet_768')]: {
     position: 'revert',
     marginTop: 'revert',
-    marginLeft: -12,
+    marginLeft: 'auto',
     marginBottom: 20,
   },
   [theme.breakpoints.up('desktop_1024')]: {

--- a/src/views/Finances/components/SectionPages/ReservesWaterfallChartSection/ReservesWaterfallChartSection.tsx
+++ b/src/views/Finances/components/SectionPages/ReservesWaterfallChartSection/ReservesWaterfallChartSection.tsx
@@ -165,10 +165,9 @@ const FilterContainer = styled('div', {
           right: 0,
         }),
   },
-
   [theme.breakpoints.up('tablet_768')]: {
     marginBottom: 20,
-    marginLeft: -12,
+    marginLeft: 'auto',
     marginTop: 'revert',
     position: 'revert',
   },


### PR DESCRIPTION
## Ticket
https://trello.com/c/7yDWN3l7/711-filters-aligned-to-the-left-side

## Description
Fix filters aligned to the left side

## What solved

- [X] Should ensure the filters are aligned to the right side.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have performed a self-review of my own chromatic changes
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have checked my code and corrected any misspellings
- [X] I have removed any unnecessary console messages
- [X] I have removed any commented code
- [X] I have checked that there are no buggy stories in Storybook