### PR TITLE
[FIX-699] Improve CustomSelect component behavior

### DIFF
--- a/src/components/CustomSelect/CustomSelect.tsx
+++ b/src/components/CustomSelect/CustomSelect.tsx
@@ -1,6 +1,5 @@
 import { ExpandMore, Check } from '@mui/icons-material';
 import { Select, MenuItem, FormControl, styled, Box, Typography } from '@mui/material';
-
 import deepmerge from '@mui/utils/deepmerge';
 import useCustomSelect from './useCustomSelect';
 import type { CustomSelectProps } from './type';
@@ -32,9 +31,27 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
     withAll,
     onChange,
   });
+
+  const onEntered = () => {
+    if (selectRef.current !== null) {
+      const menu = selectRef.current.querySelector('.MuiMenu-paper');
+      if (menu !== null) {
+        menu.scrollTop > 0 &&
+          menu.scrollTo({
+            top: 0,
+            left: 0,
+            behavior: 'instant' as ScrollBehavior,
+          });
+      }
+    }
+  };
+
   const combinedMenuProps = deepmerge(
     StyledMenuProps(theme, style?.menuWidth || 200, style?.height || 'fit-content', selectRef.current, isFixed),
-    menuProps
+    {
+      TransitionProps: { onEntered },
+      ...menuProps,
+    }
   );
 
   return (
@@ -56,21 +73,6 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
           IconComponent={ExpandMore}
           className={className}
           MenuProps={combinedMenuProps as unknown as Partial<MenuProps>}
-          onOpen={() => {
-            setTimeout(() => {
-              if (selectRef.current !== null) {
-                const menu = selectRef.current.querySelector('.MuiMenu-paper');
-                if (menu !== null) {
-                  menu.scrollTop > 0 &&
-                    menu.scrollTo({
-                      top: 0,
-                      left: 0,
-                      behavior: 'instant' as ScrollBehavior,
-                    });
-                }
-              }
-            }, 100);
-          }}
         >
           {notShowDescription && (
             <MenuItemLabel disabled>
@@ -302,6 +304,11 @@ const StyledMenuProps = (
   transformOrigin: {
     vertical: 'top',
     horizontal: 'right',
+  },
+  /* Prevent jumps when open/close the dropdown. This has accessibility implications that are recommended to be addressed in the future. */
+  disableAutoFocus: true,
+  MenuListProps: {
+    autoFocusItem: false,
   },
   sx: {
     ...(!isFixed && {

--- a/src/views/Endgame/components/NavigationTabs/NavigationTabs.tsx
+++ b/src/views/Endgame/components/NavigationTabs/NavigationTabs.tsx
@@ -74,7 +74,7 @@ export default NavigationTabs;
 const Sticky = styled('div')(({ theme }) => ({
   position: 'sticky',
   top: 64,
-  zIndex: 2,
+  zIndex: 8,
   [theme.breakpoints.up('tablet_768')]: {
     top: 98,
   },


### PR DESCRIPTION
## Ticket
https://trello.com/c/QijnXnF6/699-dropdown-remains-visible-while-scrolling-through-the-view

## Description
Improve CustomSelect component behavior

## What solved

- [X] Should fix the behavior.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have performed a self-review of my own chromatic changes
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have checked my code and corrected any misspellings
- [ ] I have removed any unnecessary console messages
- [ ] I have removed any commented code
- [ ] I have checked that there are no buggy stories in Storybook