### PR TITLE
[Fix-730] Add the correct space header and breadcrumb navigation

### DIFF
--- a/src/views/ActorProjects/ActorProjectsView.tsx
+++ b/src/views/ActorProjects/ActorProjectsView.tsx
@@ -78,9 +78,7 @@ const ActorProjectsView: React.FC<ActorProjectsViewProps> = ({ actor, actors, pr
           />
         }
       />
-      <TeamHeaderContainer>
-        <TeamHeader team={actor} withDescription={false} />
-      </TeamHeaderContainer>
+      <TeamHeader team={actor} withDescription={false} />
       <Container>
         <ContainerAllData>
           <ContainerResponsive>
@@ -150,9 +148,7 @@ const ActorProjectsView: React.FC<ActorProjectsViewProps> = ({ actor, actors, pr
 
 export default ActorProjectsView;
 
-const PageWrapper = styled(PageContainer)(() => ({
-  paddingTop: 0,
-}));
+const PageWrapper = styled(PageContainer)(() => ({}));
 
 const ContainerAllData = styled('div')(() => ({
   display: 'flex',
@@ -226,12 +222,5 @@ const TextNotFound = styled('p')(({ theme }) => ({
   [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 32,
     lineHeight: '38.4px',
-  },
-}));
-
-const TeamHeaderContainer = styled('div')(({ theme }) => ({
-  marginTop: 104,
-  [theme.breakpoints.up('tablet_768')]: {
-    marginTop: 0,
   },
 }));

--- a/src/views/ActorProjects/ActorProjectsView.tsx
+++ b/src/views/ActorProjects/ActorProjectsView.tsx
@@ -38,7 +38,7 @@ const ActorProjectsView: React.FC<ActorProjectsViewProps> = ({ actor, actors, pr
   } = useActorProjectsView(projectsData, actors, actor);
 
   return (
-    <PageWrapper>
+    <PageContainer>
       <SEOHead
         title={`Sky Fusion - ${actor.name} Ecosystem Contributor Projects`}
         description={`Learn about ${actor.name} Ecosystem Contributor's Project work: scope, deliverables, targets, resources, and key results for owned & supported projects.`}
@@ -142,13 +142,11 @@ const ActorProjectsView: React.FC<ActorProjectsViewProps> = ({ actor, actors, pr
           </ContainerResponsive>
         </ContainerAllData>
       </Container>
-    </PageWrapper>
+    </PageContainer>
   );
 };
 
 export default ActorProjectsView;
-
-const PageWrapper = styled(PageContainer)(() => ({}));
 
 const ContainerAllData = styled('div')(() => ({
   display: 'flex',

--- a/src/views/ActorProjects/ActorProjectsView.tsx
+++ b/src/views/ActorProjects/ActorProjectsView.tsx
@@ -78,7 +78,9 @@ const ActorProjectsView: React.FC<ActorProjectsViewProps> = ({ actor, actors, pr
           />
         }
       />
-      <TeamHeader team={actor} withDescription={false} />
+      <TeamHeaderContainer>
+        <TeamHeader team={actor} withDescription={false} />
+      </TeamHeaderContainer>
       <Container>
         <ContainerAllData>
           <ContainerResponsive>
@@ -224,5 +226,12 @@ const TextNotFound = styled('p')(({ theme }) => ({
   [theme.breakpoints.up('desktop_1024')]: {
     fontSize: 32,
     lineHeight: '38.4px',
+  },
+}));
+
+const TeamHeaderContainer = styled('div')(({ theme }) => ({
+  marginTop: 104,
+  [theme.breakpoints.up('tablet_768')]: {
+    marginTop: 0,
   },
 }));


### PR DESCRIPTION
## Ticket
https://trello.com/c/hkPr1d1a/730-header-is-shown-behind-the-breadcrumb

## What solved
- [X] Should the header be displayed below the breadcrumb.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
