### PR TITLE
[Fix-728] Fix the color in budget group

### DIFF
--- a/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
+++ b/src/components/AdvancedInnerTable/AdvancedInnerTable.tsx
@@ -249,7 +249,7 @@ const GroupTitle = styled('div')(({ theme }) => ({
   fontSize: 16,
   lineHeight: '22px',
   fontWeight: 600,
-  color: theme.palette.isLight ? '#231536' : '#D2D4EF',
+  color: theme.palette.isLight ? '#231536' : theme.palette.colors.gray[50],
 }));
 
 const TableRow = styled('tr')<{ borderTop?: boolean; borderBottom?: boolean }>(


### PR DESCRIPTION
## Ticket
https://trello.com/c/XGSJzbpR/728-wrong-color-in-budget-statements

## What solved
- [X]  Should apply the proper font color.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
