### PR TITLE
[Stories-737] Add the storie for card component

### DIFF
--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -1,0 +1,31 @@
+import { createThemeModeVariants } from '@ses/core/utils/storybook/factories';
+
+import Card from './Card';
+import type { Meta } from '@storybook/react';
+
+const meta: Meta<typeof Card> = {
+  title: 'Fusion/Components/Card',
+  component: Card,
+  parameters: {
+    chromatic: {
+      viewports: [375],
+      pauseAnimationAtEnd: true,
+    },
+  },
+  argTypes: {
+    children: {
+      type: 'string',
+      defaultValue: 'example',
+    },
+  },
+};
+export default meta;
+
+const variantsArgs = [
+  {
+    children: <div style={{ padding: 8 }}>Some text for example</div>,
+  },
+];
+
+const [[LightMode, DarkMode]] = createThemeModeVariants(Card, variantsArgs);
+export { LightMode, DarkMode };


### PR DESCRIPTION
## Ticket
https://trello.com/c/h6dNbqjF/737-identify-fusion-components-without-story-storybooks



## What solved

- [X] Add storie for the generic component card

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

## Screenshots (if apply)
