### PR TITLE
[FIX-733] Horizontal scroll appears when hovering over the Breakdown chart

### DIFF
--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -15,12 +15,12 @@ const ContainerStyled = styled('div')(({ theme }) => ({
   paddingRight: 16,
   width: '100%',
   maxWidth: '100%',
+  overflow: 'hidden',
 
   [theme.breakpoints.up('tablet_768')]: {
     paddingLeft: 32,
     paddingRight: 32,
   },
-
   [theme.breakpoints.up('desktop_1280')]: {
     marginLeft: 'auto',
     marginRight: 'auto',
@@ -28,7 +28,6 @@ const ContainerStyled = styled('div')(({ theme }) => ({
     paddingRight: 0,
     maxWidth: 1200,
   },
-
   [theme.breakpoints.up('desktop_1440')]: {
     maxWidth: 1312,
   },

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -15,7 +15,6 @@ const ContainerStyled = styled('div')(({ theme }) => ({
   paddingRight: 16,
   width: '100%',
   maxWidth: '100%',
-  overflow: 'hidden',
 
   [theme.breakpoints.up('tablet_768')]: {
     paddingLeft: 32,

--- a/src/views/Endgame/components/BudgetTransitionChart/BudgetTransitionChart.tsx
+++ b/src/views/Endgame/components/BudgetTransitionChart/BudgetTransitionChart.tsx
@@ -108,30 +108,10 @@ const BudgetTransitionChart: React.FC<BudgetTransitionChartProps> = ({ data, sel
       },
       padding: 0,
       borderColor: isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
-      position: (
-        point: [number, number],
-        params: EChartsOption,
-        dom: EChartsOption,
-        rect: EChartsOption,
-        size: EChartsOption
-      ) => {
-        const MORE_WITH = 10;
-        const withTooltip = size.contentSize[0];
-        const heightTooltip = size.contentSize[0];
-
-        let xPos = point[0];
-        let yPos = point[1];
-
-        const tooltipWidth = withTooltip;
-        const tooltipHeight = heightTooltip;
-
-        if (xPos + tooltipWidth + MORE_WITH > window.innerWidth) {
-          xPos -= tooltipWidth;
-        }
-
-        if (yPos + tooltipHeight + MORE_WITH > window.innerHeight) {
-          yPos -= tooltipHeight;
-        }
+      position: (point: [number, number]) => {
+        const margin = isTablet ? 0 : 8;
+        const xPos = point[0] + margin;
+        const yPos = point[1] + margin;
 
         return [xPos, yPos];
       },

--- a/src/views/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
+++ b/src/views/Finances/components/BreakdownChartSection/BreakdownChart/BreakdownChart.tsx
@@ -188,33 +188,13 @@ const BreakdownChart: React.FC<BreakdownChartProps> = ({
         borderColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
 
         borderWidth: 1,
-        position: function (
-          point: [number, number],
-          params: EChartsOption,
-          dom: EChartsOption,
-          rect: EChartsOption,
-          size: EChartsOption
-        ) {
-          const MORE_WITH = 10;
-          const withTooltip = size.contentSize[0];
-          const heightTooltip = size.contentSize[0];
+        position: (point: [number, number]) => {
+          const margin = isTablet ? 0 : 8;
+          const xPos = point[0] + margin;
+          const yPos = point[1] + margin;
 
-          let xPos = point[0];
-          let yPos = point[1];
-
-          const tooltipWidth = withTooltip;
-          const tooltipHeight = heightTooltip;
-
-          if (xPos + tooltipWidth + MORE_WITH > window.innerWidth) {
-            xPos -= tooltipWidth;
-          }
-
-          if (yPos + tooltipHeight + MORE_WITH > window.innerHeight) {
-            yPos -= tooltipHeight;
-          }
           return [xPos, yPos];
         },
-
         formatter: function (params: BarChartSeries[]) {
           // If all values are cero, don't show tooltip
           if (params.every((item) => item.value === 0)) {

--- a/src/views/Finances/components/ExpenseMetrics/ExpenseMetricsChart/ExpenseMetricsChart.tsx
+++ b/src/views/Finances/components/ExpenseMetrics/ExpenseMetricsChart/ExpenseMetricsChart.tsx
@@ -61,30 +61,10 @@ const ExpenseMetricsChart: FC<ExpenseMetricsChartProps> = ({
       padding: 0,
       borderColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
       borderWidth: 1,
-      position: (
-        point: [number, number],
-        params: EChartsOption,
-        dom: EChartsOption,
-        rect: EChartsOption,
-        size: EChartsOption
-      ) => {
-        const MORE_WITH = 10;
-        const withTooltip = size.contentSize[0];
-        const heightTooltip = size.contentSize[0];
-
-        let xPos = point[0];
-        let yPos = point[1];
-
-        const tooltipWidth = withTooltip;
-        const tooltipHeight = heightTooltip;
-
-        if (xPos + tooltipWidth + MORE_WITH > window.innerWidth) {
-          xPos -= tooltipWidth;
-        }
-
-        if (yPos + tooltipHeight + MORE_WITH > window.innerHeight) {
-          yPos -= tooltipHeight;
-        }
+      position: (point: [number, number]) => {
+        const margin = isTablet ? 0 : 8;
+        const xPos = point[0] + margin;
+        const yPos = point[1] + margin;
 
         return [xPos, yPos];
       },

--- a/src/views/Home/components/FinancesBarChart/FinancesBarChart.tsx
+++ b/src/views/Home/components/FinancesBarChart/FinancesBarChart.tsx
@@ -168,30 +168,10 @@ const FinancesBarChart: FC<FinancesBarChartProps> = ({ revenueAndSpendingData })
       },
       padding: 0,
       borderColor: theme.palette.isLight ? theme.palette.colors.slate[50] : theme.palette.colors.charcoal[800],
-      position: (
-        point: [number, number],
-        params: EChartsOption,
-        dom: EChartsOption,
-        rect: EChartsOption,
-        size: EChartsOption
-      ) => {
-        const MORE_WITH = 10;
-        const withTooltip = size.contentSize[0];
-        const heightTooltip = size.contentSize[0];
-
-        let xPos = point[0];
-        let yPos = point[1];
-
-        const tooltipWidth = withTooltip;
-        const tooltipHeight = heightTooltip;
-
-        if (xPos + tooltipWidth + MORE_WITH > window.innerWidth) {
-          xPos -= tooltipWidth;
-        }
-
-        if (yPos + tooltipHeight + MORE_WITH > window.innerHeight) {
-          yPos -= tooltipHeight;
-        }
+      position: (point: [number, number]) => {
+        const margin = isTablet ? 0 : 8;
+        const xPos = point[0] + margin;
+        const yPos = point[1] + margin;
 
         return [xPos, yPos];
       },

--- a/src/views/Home/components/FinancesLineChart/FinancesLineChart.tsx
+++ b/src/views/Home/components/FinancesLineChart/FinancesLineChart.tsx
@@ -176,22 +176,21 @@ const FinancesLineChart: FC<FinancesLineChartProps> = ({ financesData, selectedM
         rect: EChartsOption,
         size: EChartsOption
       ) => {
-        const MORE_WITH = 10;
-        const withTooltip = size.contentSize[0];
-        const heightTooltip = size.contentSize[0];
+        const tooltipWidth = size.contentSize[0];
+        const containerWidth = size.viewSize[0];
+        const margin = isTablet ? 0 : 8;
 
         let xPos = point[0];
-        let yPos = point[1];
+        const yPos = point[1] + margin;
 
-        const tooltipWidth = withTooltip;
-        const tooltipHeight = heightTooltip;
-
-        if (xPos + tooltipWidth + MORE_WITH > window.innerWidth) {
-          xPos -= tooltipWidth;
-        }
-
-        if (yPos + tooltipHeight + MORE_WITH > window.innerHeight) {
-          yPos -= tooltipHeight;
+        if (isDesk1280 || isDesk1440) {
+          if (xPos + tooltipWidth + margin > containerWidth) {
+            xPos -= tooltipWidth + margin / 4;
+          } else {
+            xPos += margin;
+          }
+        } else {
+          xPos += margin;
         }
 
         return [xPos, yPos];

--- a/src/views/Home/components/FinancesLineChartCard/FinancesLineChartCard.tsx
+++ b/src/views/Home/components/FinancesLineChartCard/FinancesLineChartCard.tsx
@@ -104,6 +104,7 @@ export default FinancesLineChartCard;
 const Container = styled(Card)(({ theme }) => ({
   width: '100%',
   padding: '0px 0px 16px',
+  overflow: 'hidden',
 
   [theme.breakpoints.up('tablet_768')]: {
     padding: 16,


### PR DESCRIPTION
## Ticket
https://trello.com/c/QKH5ZW0S/733-horizontal-scroll-appears-when-hovering-over-the-breakdown-chart

## Description
Horizontal scroll appears when hovering over the Breakdown chart

## What solved
- [X] Should the tooltip be fully displayed.
- [X] Should ensure that the scroll bar doesn't appear.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have performed a self-review of my own chromatic changes
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have checked my code and corrected any misspellings
- [X] I have removed any unnecessary console messages
- [X] I have removed any commented code
- [X] I have checked that there are no buggy stories in Storybook