### PR TITLE
[FIX-746] Color misrepresentation in PH September 2024

### DIFF
--- a/src/components/BudgetStatement/BudgetStatementForecast/BarWithDottedLine.tsx
+++ b/src/components/BudgetStatement/BudgetStatementForecast/BarWithDottedLine.tsx
@@ -37,21 +37,28 @@ const BarWithDottedLine: React.FC<Props> = ({ value, relativeValue, month, isTot
   };
 
   if (!showComponent) return <ContainerNA>N/A</ContainerNA>;
-  const barColor = getProgressiveBarColor(value, relativeValue, isLight, hover);
-  const percent = getPercentFullBar(value, relativeValue);
-  const displacement = getDisplacementDashLine(value, relativeValue);
-  const borderColor = getBorderColor(value, relativeValue, isLight);
+
+  const valueFixed = Number(value.toFixed(2));
+  const relativeValueFixed = Number(relativeValue.toFixed(2));
+
+  const barColor = getProgressiveBarColor(valueFixed, relativeValueFixed, isLight, hover);
+  const percent = getPercentFullBar(valueFixed, relativeValueFixed);
+  const displacement = getDisplacementDashLine(valueFixed, relativeValueFixed);
+  const borderColor = getBorderColor(valueFixed, relativeValueFixed, isLight);
+
   return (
     <Container>
-      <Forecast isTotal={isTotal} isNegative={value < 0}>
-        {usLocalizedNumber(value, 2)}
+      <Forecast isTotal={isTotal} isNegative={valueFixed < 0}>
+        {usLocalizedNumber(valueFixed, 2)}
       </Forecast>
       <ContainerBar>
         <BudgetBar>{<BarPercent width={percent} color={barColor} />}</BudgetBar>
 
         <SESTooltipStyled
           borderColor={borderColor}
-          content={<PopoverForecastDescription relativeValue={relativeValue} value={value} month={monthFormatted} />}
+          content={
+            <PopoverForecastDescription relativeValue={relativeValueFixed} value={valueFixed} month={monthFormatted} />
+          }
         >
           <ContendBarForSpace
             onMouseEnter={handleMouseOver}
@@ -63,7 +70,7 @@ const BarWithDottedLine: React.FC<Props> = ({ value, relativeValue, month, isTot
           </ContendBarForSpace>
         </SESTooltipStyled>
       </ContainerBar>
-      <BudgetCap>{usLocalizedNumber(relativeValue, 2)}</BudgetCap>
+      <BudgetCap>{usLocalizedNumber(relativeValueFixed, 2)}</BudgetCap>
     </Container>
   );
 };


### PR DESCRIPTION
## Ticket
https://trello.com/c/fQAz9iPe/746-color-misrepresentation-in-ph-september-2024

## Description
Color misrepresentation in PH September 2024

## What solved
- [X] Should apply the proper color.
- [X] Should fix the % in the Popover.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have performed a self-review of my own chromatic changes
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have checked my code and corrected any misspellings
- [X] I have removed any unnecessary console messages
- [X] I have removed any commented code
- [X] I have checked that there are no buggy stories in Storybook