### PR TITLE
fix: outdated content and broken links in endgame

### DIFF
--- a/src/views/Endgame/components/KeyChangesBudgetTransitionStatusImportantLink/KeyChangesBudgetTransitionStatusImportantLink.tsx
+++ b/src/views/Endgame/components/KeyChangesBudgetTransitionStatusImportantLink/KeyChangesBudgetTransitionStatusImportantLink.tsx
@@ -11,7 +11,7 @@ const KeyChangesBudgetTransitionStatusImportantLink: React.FC = () => (
 
     <ContainerButton>
       <ExternalLinkButtonStyled href="https://endgame.makerdao.com">endgame.makerdao.com</ExternalLinkButtonStyled>
-      <ExternalLinkButtonStyled href="https://forum.makerdao.com">forum.makerdao.com</ExternalLinkButtonStyled>
+      <ExternalLinkButtonStyled href="https://forum.sky.money">forum.sky.money</ExternalLinkButtonStyled>
     </ContainerButton>
   </CardContainer>
 );

--- a/src/views/Endgame/components/KeyChangesSections/Sections/GovernanceSection.tsx
+++ b/src/views/Endgame/components/KeyChangesSections/Sections/GovernanceSection.tsx
@@ -14,7 +14,7 @@ const GovernanceSection: React.FC = () => (
         },
         {
           title: 'Overview of recognized delegates legacy budgets',
-          href: 'https://expenses.makerdao.network/delegates',
+          href: 'https://fusion.sky.money/contributors/recognized-delegates',
         },
       ]}
     >


### PR DESCRIPTION
## Ticket
https://trello.com/c/nvQM7CwD/906-outdated-content-and-broken-links-on-endgame-budget-structure-page

## Description
- Should fix the https://fusion.sky.money/delegates link
- Should forum.makerdao.com directs to forum.sky.money