### PR TITLE
fix(homepage): reenable finances section

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,16 +3,17 @@ import type { Roadmap } from '@/core/models/interfaces/roadmaps';
 import type { Team } from '@/core/models/interfaces/team';
 import { fetchActors } from '@/views/EcosystemActorsIndex/api/queries';
 import HomeView from '@/views/Home/HomeView';
+import type { FormattedFinancesData } from '@/views/Home/api/finances';
+import { getFinancesData } from '@/views/Home/api/finances';
 import { getGovernanceProposals } from '@/views/Home/api/makervoteQueries';
+import type { RevenueAndSpendingRecords } from '@/views/Home/api/revenueAndSpending';
 import { getScopeOfWorkState } from '@/views/RoadmapMilestones/api/queries';
 import { getChiefHat } from '@/web3/api/governance';
 import type { GetServerSideProps, NextPage } from 'next';
 
-// TODO: Re-enable finances data once there's a replacement data source for Makerburn, as it was decommissioned.
-// Ignore commented code, it was left for quick re-enabling of finances data.
 interface HomePageProps {
-  // revenueAndSpendingData: RevenueAndSpendingRecords;
-  // financesData: FormattedFinancesData;
+  revenueAndSpendingData: RevenueAndSpendingRecords;
+  financesData: FormattedFinancesData;
   teams: Team[];
   governanceProposals: ExtendedExecutiveProposal[];
   roadmaps: Roadmap[];
@@ -20,16 +21,16 @@ interface HomePageProps {
 }
 
 const HomePage: NextPage<HomePageProps> = ({
-  // revenueAndSpendingData,
-  // financesData,
+  revenueAndSpendingData,
+  financesData,
   teams,
   governanceProposals,
   roadmaps,
   hatAddress,
 }) => (
   <HomeView
-    // revenueAndSpendingData={revenueAndSpendingData}
-    // financesData={financesData}
+    revenueAndSpendingData={revenueAndSpendingData}
+    financesData={financesData}
     teams={teams}
     governanceProposals={governanceProposals}
     roadmaps={roadmaps}
@@ -41,25 +42,61 @@ export default HomePage;
 
 export const getServerSideProps: GetServerSideProps = async () => {
   const [
+    // TODO: re-enable revenue and spending fetching once there's a replacement for makerburn api
     // revenueAndSpendingData,
-    // financesData,
+    financesData,
     teams,
     governanceProposals,
     roadmaps,
     hatAddress,
   ] = await Promise.all([
     // getRevenueAndSpendingData(),
-    // getFinancesData(),
+    getFinancesData(),
     fetchActors(),
     getGovernanceProposals(),
     getScopeOfWorkState(),
     getChiefHat(),
   ]);
 
+  const revenueAndSpendingData = {
+    2021: {
+      fees: 0,
+      liquidationIncome: 0,
+      psm: 0,
+      daiSpent: 0,
+      mkrVesting: 0,
+      dsr: 0,
+    },
+    2022: {
+      fees: 0,
+      liquidationIncome: 0,
+      psm: 0,
+      daiSpent: 0,
+      mkrVesting: 0,
+      dsr: 0,
+    },
+    2023: {
+      fees: 0,
+      liquidationIncome: 0,
+      psm: 0,
+      daiSpent: 0,
+      mkrVesting: 0,
+      dsr: 0,
+    },
+    2024: {
+      fees: 0,
+      liquidationIncome: 0,
+      psm: 0,
+      daiSpent: 0,
+      mkrVesting: 0,
+      dsr: 0,
+    },
+  };
+
   return {
     props: {
-      // revenueAndSpendingData,
-      // financesData,
+      revenueAndSpendingData,
+      financesData,
       teams,
       governanceProposals,
       roadmaps,

--- a/src/views/Home/Home.stories.tsx
+++ b/src/views/Home/Home.stories.tsx
@@ -14,6 +14,8 @@ import { DefaultRoadmap } from '@/views/RoadmapMilestones/staticData';
 import { defaultSocials } from '../EcosystemActorsIndex/utils/utils';
 import HomeView from './HomeView';
 import { ForumCategories } from './components/GovernanceSection/ForumOverview/categories';
+import { financesDataMocked } from './staticData';
+import type { HomeViewProps } from './HomeView';
 import type { Meta } from '@storybook/react';
 
 const meta: Meta<typeof HomeView> = {
@@ -35,45 +37,45 @@ export default meta;
 
 const variantsArgs = [
   {
-    // revenueAndSpendingData: {
-    //   2021: {
-    //     fees: 50000,
-    //     liquidationIncome: 120000,
-    //     psm: 30000,
-    //     daiSpent: 70000,
-    //     mkrVesting: 20000,
-    //     dsr: 10000,
-    //     annualProfit: 100000,
-    //   },
-    //   2022: {
-    //     fees: 60000,
-    //     liquidationIncome: 140000,
-    //     psm: 35000,
-    //     daiSpent: 80000,
-    //     mkrVesting: 25000,
-    //     dsr: 15000,
-    //     annualProfit: 115000,
-    //   },
-    //   2023: {
-    //     fees: 70000,
-    //     liquidationIncome: 160000,
-    //     psm: 40000,
-    //     daiSpent: 90000,
-    //     mkrVesting: 30000,
-    //     dsr: 20000,
-    //     annualProfit: 130000,
-    //   },
-    //   2024: {
-    //     fees: 80000,
-    //     liquidationIncome: 180000,
-    //     psm: 45000,
-    //     daiSpent: 100000,
-    //     mkrVesting: 35000,
-    //     dsr: 25000,
-    //     annualProfit: 145000,
-    //   },
-    // } as HomeViewProps['revenueAndSpendingData'],
-    // financesData: financesDataMocked,
+    revenueAndSpendingData: {
+      2021: {
+        fees: 50000,
+        liquidationIncome: 120000,
+        psm: 30000,
+        daiSpent: 70000,
+        mkrVesting: 20000,
+        dsr: 10000,
+        annualProfit: 100000,
+      },
+      2022: {
+        fees: 60000,
+        liquidationIncome: 140000,
+        psm: 35000,
+        daiSpent: 80000,
+        mkrVesting: 25000,
+        dsr: 15000,
+        annualProfit: 115000,
+      },
+      2023: {
+        fees: 70000,
+        liquidationIncome: 160000,
+        psm: 40000,
+        daiSpent: 90000,
+        mkrVesting: 30000,
+        dsr: 20000,
+        annualProfit: 130000,
+      },
+      2024: {
+        fees: 80000,
+        liquidationIncome: 180000,
+        psm: 45000,
+        daiSpent: 100000,
+        mkrVesting: 35000,
+        dsr: 25000,
+        annualProfit: 145000,
+      },
+    } as HomeViewProps['revenueAndSpendingData'],
+    financesData: financesDataMocked,
     governanceProposals: [
       {
         proposalBlurb:

--- a/src/views/Home/HomeView.tsx
+++ b/src/views/Home/HomeView.tsx
@@ -6,17 +6,18 @@ import type { ExtendedExecutiveProposal } from '@/core/models/interfaces/makervo
 import type { Roadmap } from '@/core/models/interfaces/roadmaps';
 import type { Team } from '@/core/models/interfaces/team';
 import ContributorsSection from '../Contributors/components/Sections/ContributorsSections';
+import FinancesSection from './components/FinancesSection/FinancesSection';
 import GovernanceSection from './components/GovernanceSection/GovernanceSection';
 import HeaderCard from './components/HeaderCard/HeaderCard';
 import HomeButton from './components/HomeButton/HomeButton';
 import RoadmapSection from './components/RoadmapSection/RoadmapSection';
+import type { FormattedFinancesData } from './api/finances';
+import type { RevenueAndSpendingRecords } from './api/revenueAndSpending';
 import type { FC } from 'react';
 
-// TODO: Re-enable finances data once there's a replacement data source for Makerburn, as it was decommissioned.
-
 export interface HomeViewProps {
-  // revenueAndSpendingData: RevenueAndSpendingRecords;
-  // financesData: FormattedFinancesData;
+  revenueAndSpendingData: RevenueAndSpendingRecords;
+  financesData: FormattedFinancesData;
   teams: Team[];
   governanceProposals: ExtendedExecutiveProposal[];
   roadmaps: Roadmap[];
@@ -24,8 +25,8 @@ export interface HomeViewProps {
 }
 
 const HomeView: FC<HomeViewProps> = ({
-  // revenueAndSpendingData,
-  // financesData,
+  revenueAndSpendingData,
+  financesData,
   teams,
   governanceProposals,
   roadmaps,
@@ -42,7 +43,7 @@ const HomeView: FC<HomeViewProps> = ({
 
     <Container>
       <HeaderCard />
-      {/* <FinancesSection revenueAndSpendingData={revenueAndSpendingData} financesData={financesData} /> */}
+      <FinancesSection revenueAndSpendingData={revenueAndSpendingData} financesData={financesData} />
       <GovernanceSection governanceProposals={governanceProposals} hatAddress={hatAddress} />
       <ContributorsSection teams={teams} />
       <RoadmapSection roadmaps={roadmaps} />


### PR DESCRIPTION
## Ticket
https://trello.com/c/jHWLRolG/1219-disable-any-makerburn-data-sources-in-fusion-dashboard

## Description
Reenabled the finances section of the hompage, mocking the API response with all values in 0

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have performed a self-review of my own chromatic changes
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] I have removed any unnecessary console messages
- [x] I have removed any commented code
- [x] I have checked that there are no buggy stories in Storybook

